### PR TITLE
Matrix Chains

### DIFF
--- a/examples/code/examples/code-viewer.rs
+++ b/examples/code/examples/code-viewer.rs
@@ -2,11 +2,11 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use cosmic_text::{fontdb, FontSystem};
-use massive_scene::PositionedShape;
 use tracing::info;
 use winit::dpi::LogicalSize;
 
 use massive_geometry::{Camera, SizeI};
+use massive_scene::PositionedShape;
 use massive_shell::{shell, ApplicationContext};
 use shared::{
     application::{Application, UpdateResponse},
@@ -101,11 +101,12 @@ async fn code_viewer(mut ctx: ApplicationContext) -> Result<()> {
     let mut application = Application::new(SizeI::new(1280, height as u64));
     let mut current_matrix = application.matrix();
     let matrix = director.cast(current_matrix);
+    let position = director.cast(matrix.clone().into());
 
     // Hold the positioned shapes in this context, otherwise they will disappear.
     let _positioned_shapes: Vec<_> = glyph_runs
         .into_iter()
-        .map(|run| director.cast(PositionedShape::new(matrix.clone(), run)))
+        .map(|run| director.cast(PositionedShape::new(position.clone(), run)))
         .collect();
 
     director.action()?;

--- a/examples/code/examples/code.rs
+++ b/examples/code/examples/code.rs
@@ -282,10 +282,11 @@ async fn application(mut ctx: ApplicationContext) -> Result<()> {
 
     let mut current_matrix = application.matrix();
     let matrix = director.cast(current_matrix);
+    let position = director.cast(matrix.clone().into());
 
     let _positioned_shapes: Vec<_> = glyph_runs
         .into_iter()
-        .map(|run| director.cast(PositionedShape::new(matrix.clone(), run)))
+        .map(|run| director.cast(PositionedShape::new(position.clone(), run)))
         .collect();
 
     director.action()?;

--- a/examples/markdown/examples/emojis.rs
+++ b/examples/markdown/examples/emojis.rs
@@ -16,10 +16,10 @@ use inlyne::{
     Element,
 };
 use log::info;
-use massive_scene::PositionedShape;
 use winit::dpi::LogicalSize;
 
 use massive_geometry::{Camera, SizeI, Vector3};
+use massive_scene::PositionedShape;
 use massive_shell::{shell, ApplicationContext};
 
 use shared::{
@@ -171,11 +171,12 @@ async fn emojis(mut ctx: ApplicationContext) -> Result<()> {
     let mut application = Application::new(SizeI::new(page_width as _, page_height));
     let mut current_matrix = application.matrix();
     let matrix = director.cast(current_matrix);
+    let position = director.cast(matrix.clone().into());
 
     // Hold the positioned shapes in this context, otherwise they will disappear.
     let _positioned_shapes: Vec<_> = glyph_runs
         .into_iter()
-        .map(|run| director.cast(PositionedShape::new(matrix.clone(), run)))
+        .map(|run| director.cast(PositionedShape::new(position.clone(), run)))
         .collect();
 
     director.action()?;

--- a/examples/markdown/examples/markdown.rs
+++ b/examples/markdown/examples/markdown.rs
@@ -89,11 +89,12 @@ async fn application(mut ctx: ApplicationContext) -> Result<()> {
     let mut application = Application::new(page_size);
     let mut current_matrix = application.matrix();
     let matrix = director.cast(current_matrix);
+    let position = director.cast(matrix.clone().into());
 
     // Hold the positioned shapes in this context, otherwise they will disappear.
     let _positioned_shapes: Vec<_> = glyph_runs
         .into_iter()
-        .map(|run| director.cast(PositionedShape::new(matrix.clone(), run)))
+        .map(|run| director.cast(PositionedShape::new(position.clone(), run)))
         .collect();
 
     director.action()?;

--- a/examples/syntax/examples/syntax.rs
+++ b/examples/syntax/examples/syntax.rs
@@ -106,11 +106,12 @@ async fn syntax(mut ctx: ApplicationContext) -> Result<()> {
     let mut application = Application::new((1280, height as u64));
     let mut current_matrix = application.matrix();
     let matrix = director.cast(current_matrix);
+    let position = director.cast(matrix.clone().into());
 
     // Hold the positioned shapes in this context, otherwise they will disappear.
     let _positioned_shapes: Vec<_> = glyph_runs
         .into_iter()
-        .map(|run| director.cast(PositionedShape::new(matrix.clone(), run)))
+        .map(|run| director.cast(PositionedShape::new(position.clone(), run)))
         .collect();
 
     director.action()?;

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -103,7 +103,8 @@ impl<'window> Renderer<'window> {
         font_system: &mut text::FontSystem,
         changes: impl IntoIterator<Item = SceneChange>,
     ) -> Result<()> {
-        self.scene.reset();
+        // Reset the scene.
+        self.scene = Scene::default();
         self.apply_changes(font_system, changes)
     }
 
@@ -113,9 +114,7 @@ impl<'window> Renderer<'window> {
         font_system: &mut text::FontSystem,
         changes: impl IntoIterator<Item = SceneChange>,
     ) -> Result<()> {
-        for change in changes {
-            self.scene.apply(change);
-        }
+        self.scene.transact(changes);
 
         let mut context = PreparationContext {
             device: &self.device,

--- a/renderer/src/scene/id_table.rs
+++ b/renderer/src/scene/id_table.rs
@@ -47,6 +47,21 @@ impl<T> IdTable<T> {
         }
     }
 
+    /// Returns a reference to a value at `id``.
+    ///
+    /// May resize and create defaults.
+    pub fn get_or_default(&mut self, id: Id) -> &T
+    where
+        T: Default,
+    {
+        let index = *id;
+        if index >= self.rows.len() {
+            self.rows.resize_with(index + 1, || T::default())
+        }
+
+        &self.rows[index]
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.rows.iter()
     }

--- a/renderer/src/scene/id_table.rs
+++ b/renderer/src/scene/id_table.rs
@@ -1,6 +1,9 @@
 //! An id associated table of objects.
 
-use std::{mem, ops::Index};
+use std::{
+    mem,
+    ops::{Index, IndexMut},
+};
 
 use massive_scene::{Change, Id};
 
@@ -53,8 +56,8 @@ impl<T> IdTable<T> {
         self.rows.iter().filter_map(|v| v.as_ref())
     }
 
-    pub fn reset(&mut self) {
-        self.rows.clear();
+    pub(crate) fn rows(&mut self) -> &mut [Option<T>] {
+        &mut self.rows
     }
 }
 
@@ -64,5 +67,11 @@ impl<T> Index<Id> for IdTable<T> {
 
     fn index(&self, index: Id) -> &Self::Output {
         self.rows[*index].as_ref().unwrap()
+    }
+}
+
+impl<T> IndexMut<Id> for IdTable<T> {
+    fn index_mut(&mut self, index: Id) -> &mut Self::Output {
+        self.rows[*index].as_mut().unwrap()
     }
 }

--- a/renderer/src/scene/id_table.rs
+++ b/renderer/src/scene/id_table.rs
@@ -1,15 +1,12 @@
 //! An id associated table of objects.
 
-use std::{
-    mem,
-    ops::{Index, IndexMut},
-};
+use std::ops::{Index, IndexMut};
 
 use massive_scene::Id;
 
 #[derive(Debug)]
 pub struct IdTable<T> {
-    // Don't dare to make this pub, use `rows_mut()` instead.
+    // Don't dare to make this pub! Use `rows_mut()` instead.
     rows: Vec<T>,
 }
 
@@ -33,21 +30,7 @@ impl<T> IdTable<T> {
         self.rows[index] = value;
     }
 
-    #[allow(unused)]
-    #[must_use]
-    pub fn take(&mut self, id: Id) -> Option<T>
-    where
-        T: Default,
-    {
-        let index = *id;
-        if index < self.rows.len() {
-            Some(mem::take(&mut self.rows[index]))
-        } else {
-            None
-        }
-    }
-
-    /// Returns a reference to a value at `id``.
+    /// Returns a reference to a value at `id`.
     ///
     /// May resize and create defaults.
     pub fn get_or_default(&mut self, id: Id) -> &T

--- a/renderer/src/scene/mod.rs
+++ b/renderer/src/scene/mod.rs
@@ -1,41 +1,154 @@
-use std::collections::HashMap;
+use std::{cell::RefCell, collections::HashMap};
 
 use id_table::IdTable;
 use massive_geometry::Matrix4;
-use massive_scene::{Id, PositionedRenderShape, SceneChange, Shape};
+use massive_scene::{Change, Id, PositionRenderObj, PositionedRenderShape, SceneChange, Shape};
+use versioning::{Computed, Version, Versioned};
 
 mod id_table;
+mod versioning;
 
 #[derive(Debug, Default)]
 pub struct Scene {
-    matrices: IdTable<Matrix4>,
+    /// The version of newest values in the tables.
+    current_version: Version,
+
+    matrices: IdTable<Versioned<Matrix4>>,
+    positions: IdTable<Versioned<PositionRenderObj>>,
     shapes: IdTable<PositionedRenderShape>,
+
+    caches: RefCell<SceneCaches>,
 }
 
 impl Scene {
-    pub fn apply(&mut self, change: SceneChange) {
+    /// Integrate a number of scene changes as single transaction into the scene.
+    ///
+    /// The transaction is given a new version number, which is then treated as the most recent
+    /// version and the current version of the whole scene.
+    pub fn transact(&mut self, changes: impl IntoIterator<Item = SceneChange>) {
+        self.current_version += 1;
+        for change in changes {
+            self.apply(change, self.current_version)
+        }
+    }
+
+    fn apply(&mut self, change: SceneChange, version: Version) {
         match change {
-            SceneChange::Matrix(change) => self.matrices.apply(change),
+            SceneChange::Matrix(change) => self.matrices.apply_versioned(change, version),
+            SceneChange::Position(change) => self.positions.apply_versioned(change, version),
             SceneChange::PositionedShape(change) => self.shapes.apply(change),
         }
     }
 
-    pub fn grouped_shapes(&self) -> impl Iterator<Item = (&Matrix4, Vec<&Shape>)> {
+    /// Returns a set of grouped shape by matrix.
+    ///
+    /// TODO: This should not be &mut self, because it updates computed values only.
+    pub fn grouped_shapes(&self) -> impl Iterator<Item = (Matrix4, Vec<&Shape>)> {
         let mut map: HashMap<Id, Vec<&Shape>> = HashMap::new();
 
         for positioned in self.shapes.iter() {
-            let matrix_id = positioned.matrix;
-            map.entry(matrix_id).or_default().push(&positioned.shape);
+            let position_id = positioned.position;
+            map.entry(position_id).or_default().push(&positioned.shape);
         }
 
-        map.into_iter().map(|(matrix_id, shapes)| {
-            let matrix = &self.matrices[matrix_id];
+        // Update all matrices that are in use.
+        {
+            let mut caches = self.caches.borrow_mut();
+            for position_id in map.keys() {
+                self.resolve_positioned_matrix(*position_id, &mut caches);
+            }
+        }
+
+        // Create the group iterator.
+
+        let caches = self.caches.borrow();
+
+        map.into_iter().map(move |(position_id, shapes)| {
+            // Ensure the matrix is up2date.
+            // We can't return a reference to matrix, because this would also borrow `caches``.
+            let matrix = *caches.positions_matrix[position_id];
             (matrix, shapes)
         })
     }
 
-    pub fn reset(&mut self) {
-        self.matrices.reset();
-        self.shapes.reset();
+    /// Compute - if needed - the matrix of a position.
+    ///
+    /// When this function returns the matrix at `position_id` is up to date with the current
+    /// version and can be used for rendering.
+    ///
+    /// We don't return a reference to the result here, because the borrow checker would make this
+    /// recursive function invocation uncessarily more complex.
+    ///
+    /// TODO: Unrecurse this. There might be degenerate cases of large dependency chains.
+    fn resolve_positioned_matrix(&self, position_id: Id, caches: &mut SceneCaches) {
+        let current_version = self.current_version;
+        // Already validated at the latest version? Done.
+        if caches.positions_matrix[position_id].validated_at == current_version {
+            return;
+        }
+
+        let position = &self.positions[position_id];
+        let (parent_id, matrix) = (position.parent, position.matrix);
+
+        // Find out the max version of all the immeidate and (indirect / computed) dependencies.
+
+        // Get the _three_ versions of the elements this one is computed on.
+        // a) The self position's version.
+        // b) The local matrix's version.
+        // c) The computed matrix of the parent (representing all its dependencies).
+        let max_deps_version = position.updated_at.max(self.matrices[matrix].updated_at);
+
+        // Combine with the optional parent.
+        let max_deps_version = {
+            if let Some(parent_id) = parent_id {
+                // Be sure the parent is up to date.
+                self.resolve_positioned_matrix(parent_id, caches);
+                caches.positions_matrix[parent_id]
+                    .max_deps_version
+                    .max(max_deps_version)
+            } else {
+                max_deps_version
+            }
+        };
+
+        // If the max_deps_version is smaller or equal to the current one, the value is ok and can
+        // be marked as validated for this round.
+        {
+            let positioned_matrix = &mut caches.positions_matrix[position_id];
+            if max_deps_version <= positioned_matrix.max_deps_version {
+                positioned_matrix.validated_at = current_version;
+                return;
+            }
+        }
+
+        // Compute a new value.
+
+        let local_matrix = &*self.matrices[matrix];
+        let new_value = parent_id.map_or_else(
+            || *local_matrix,
+            |parent_id| *caches.positions_matrix[parent_id] * local_matrix,
+        );
+
+        caches.positions_matrix[position_id] = Computed {
+            validated_at: current_version,
+            max_deps_version,
+            value: new_value,
+        };
     }
+}
+
+impl<T> IdTable<Versioned<T>> {
+    pub fn apply_versioned(&mut self, change: Change<T>, version: Version) {
+        match change {
+            Change::Create(id, value) => self.put(id, Versioned::new(value, version)),
+            Change::Delete(id) => self.remove(id),
+            Change::Update(id, value) => self.rows()[*id] = Some(Versioned::new(value, version)),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SceneCaches {
+    // The result of a positioned computation.
+    positions_matrix: IdTable<Computed<Matrix4>>,
 }

--- a/renderer/src/scene/mod.rs
+++ b/renderer/src/scene/mod.rs
@@ -180,8 +180,10 @@ impl<T> IdTable<Option<Versioned<T>>> {
 impl Default for Computed<Matrix4> {
     fn default() -> Self {
         Self {
-            validated_at: Default::default(),
-            max_deps_version: Default::default(),
+            validated_at: 0,
+            max_deps_version: 0,
+            // OO: is there a wait to use `::ZERO` / the trait `ConstZero` from num_traits for
+            // example?
             value: Matrix4::zero(),
         }
     }

--- a/renderer/src/scene/versioning.rs
+++ b/renderer/src/scene/versioning.rs
@@ -1,0 +1,58 @@
+use std::ops::Deref;
+
+pub type Version = u64;
+
+#[derive(Debug)]
+pub struct Versioned<T> {
+    value: T,
+    pub updated_at: Version,
+}
+
+impl<T> Deref for Versioned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> Versioned<T> {
+    pub fn new(value: T, version: Version) -> Self {
+        Self {
+            value,
+            updated_at: version,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn update(&mut self, value: T, version: Version) {
+        assert!(version > self.updated_at);
+        self.value = value;
+        self.updated_at = version;
+    }
+}
+
+#[derive(Debug)]
+pub struct Computed<V> {
+    /// This is last the time the `max_deps_version` and computed value was validated to be
+    /// consistent with its dependencies.
+    ///
+    /// If `validated_at` is less than the curreent tick, `max_deps_version` and `value` may be
+    /// outdated.
+    pub validated_at: Version,
+    /// The maximum version of all its dependencies. May be outdated if `checked_at` does not equals
+    /// the current version.
+    pub max_deps_version: Version,
+    /// The value at `max_deps_version`. Because of laziness, this value may be computed at a later
+    /// time tick, but it always represents the result of a computation matching the dependencies at
+    /// `max_deps_version`.
+    pub value: V,
+}
+
+impl<T> Deref for Computed<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}

--- a/scene/src/change_tracker.rs
+++ b/scene/src/change_tracker.rs
@@ -2,7 +2,7 @@ use std::{any::TypeId, mem};
 
 use massive_geometry as geometry;
 
-use crate::{Id, Object, PositionedRenderShape, PositionedShape};
+use crate::{Id, Object, PositionRenderObj, PositionedRenderShape, PositionedShape};
 
 #[derive(Debug)]
 pub enum Change<T> {
@@ -14,6 +14,7 @@ pub enum Change<T> {
 #[derive(Debug)]
 pub enum SceneChange {
     Matrix(Change<geometry::Matrix4>),
+    Position(Change<PositionRenderObj>),
     PositionedShape(Change<PositionedRenderShape>),
 }
 
@@ -35,11 +36,11 @@ impl SceneChange {
 pub struct ChangeTracker(Vec<SceneChange>);
 
 impl ChangeTracker {
-    pub fn create<T: Object>(&mut self, id: Id, value: T::Uploaded) {
+    pub fn create<T: Object>(&mut self, id: Id, value: T::Change) {
         self.push::<T>(Change::Create(id, value))
     }
 
-    pub fn update<T: Object>(&mut self, id: Id, value: T::Uploaded) {
+    pub fn update<T: Object>(&mut self, id: Id, value: T::Change) {
         self.push::<T>(Change::Update(id, value))
     }
 
@@ -47,7 +48,7 @@ impl ChangeTracker {
         self.push::<T>(Change::Delete(id))
     }
 
-    fn push<T: Object>(&mut self, change: Change<T::Uploaded>) {
+    fn push<T: Object>(&mut self, change: Change<T::Change>) {
         self.0.push(T::promote_change(change));
     }
 

--- a/scene/src/objects.rs
+++ b/scene/src/objects.rs
@@ -1,0 +1,164 @@
+use derive_more::From;
+
+use crate::{Change, Handle, Id, Object, SceneChange};
+use massive_geometry as geometry;
+use massive_shapes::{GlyphRun, Quads};
+
+#[derive(Debug, From)]
+pub enum Shape {
+    GlyphRun(GlyphRun),
+    Quads(Quads),
+}
+
+#[derive(Debug)]
+pub struct PositionedShape {
+    pub position: Handle<Position>,
+    pub shape: Shape,
+}
+
+#[derive(Debug)]
+pub struct PositionedRenderShape {
+    pub position: Id,
+    pub shape: Shape,
+}
+
+impl Object for PositionedShape {
+    // We keep the position handle here.
+    type Keep = Handle<Position>;
+    // And upload the render shape.
+    type Change = PositionedRenderShape;
+
+    fn split(self) -> (Self::Keep, Self::Change) {
+        let PositionedShape { position, shape } = self;
+        let shape = PositionedRenderShape {
+            position: position.id(),
+            shape,
+        };
+        (position, shape)
+    }
+
+    fn promote_change(change: Change<Self::Change>) -> SceneChange {
+        SceneChange::PositionedShape(change)
+    }
+}
+
+impl PositionedShape {
+    pub fn new(position: Handle<Position>, shape: impl Into<Shape>) -> Self {
+        Self {
+            position,
+            shape: shape.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Position {
+    pub parent: Option<Handle<Position>>,
+    pub matrix: Matrix,
+}
+
+impl From<Matrix> for Position {
+    fn from(matrix: Matrix) -> Self {
+        Position {
+            parent: None,
+            matrix,
+        }
+    }
+}
+
+impl Object for Position {
+    type Keep = Self;
+    type Change = PositionRenderObj;
+
+    fn promote_change(change: Change<Self::Change>) -> SceneChange {
+        SceneChange::Position(change)
+    }
+
+    fn split(self) -> (Self::Keep, Self::Change) {
+        let parent = self.parent.as_ref().map(|p| p.id());
+        let matrix = self.matrix.id();
+        (self, PositionRenderObj { parent, matrix })
+    }
+}
+
+#[derive(Debug)]
+pub struct PositionRenderObj {
+    pub parent: Option<Id>,
+    pub matrix: Id,
+}
+
+pub type Matrix = Handle<geometry::Matrix4>;
+
+impl Object for geometry::Matrix4 {
+    type Keep = ();
+    type Change = Self;
+
+    fn split(self) -> (Self::Keep, Self::Change) {
+        ((), self)
+    }
+
+    fn promote_change(change: Change<Self::Change>) -> SceneChange {
+        SceneChange::Matrix(change)
+    }
+}
+
+pub mod legacy {
+    use super::Handle;
+    use crate::{Director, Position, PositionedShape, SceneChange};
+    use anyhow::Result;
+    use massive_geometry::Matrix4;
+    use massive_shapes::{GlyphRunShape, QuadsShape, Shape};
+    use std::{collections::HashMap, rc::Rc};
+    use tokio::sync::mpsc;
+
+    pub fn bootstrap_scene_changes(shapes: Vec<Shape>) -> Result<Vec<SceneChange>> {
+        let (channel_tx, mut channel_rx) = mpsc::channel(1);
+
+        let mut director = Director::from_sender(channel_tx);
+
+        // The shapes must be alive
+
+        {
+            // Keep the positioned shapes until the director ran through.
+            let _positioned = into_positioned_shapes(&mut director, shapes);
+            director.action()?;
+        }
+
+        Ok(channel_rx.try_recv().unwrap_or_default())
+    }
+
+    pub fn into_positioned_shapes(
+        director: &mut Director,
+        shapes: Vec<Shape>,
+    ) -> Vec<Handle<PositionedShape>> {
+        let mut position_handles: HashMap<*const Matrix4, Handle<Position>> = HashMap::new();
+        let mut positioned_shapes = Vec::with_capacity(shapes.len());
+
+        for shape in shapes {
+            let matrix = match &shape {
+                Shape::GlyphRun(GlyphRunShape { model_matrix, .. }) => model_matrix,
+                Shape::Quads(QuadsShape { model_matrix, .. }) => model_matrix,
+            };
+
+            let position = position_handles.entry(Rc::as_ptr(matrix)).or_insert_with(
+                || -> Handle<Position> {
+                    let matrix = director.cast(**matrix);
+                    director.cast(matrix.into())
+                },
+            );
+
+            let positioned = match shape {
+                Shape::GlyphRun(GlyphRunShape { run, .. }) => {
+                    PositionedShape::new(position.clone(), run)
+                }
+                Shape::Quads(QuadsShape { quads, .. }) => {
+                    PositionedShape::new(position.clone(), quads)
+                }
+            };
+
+            positioned_shapes.push(director.cast(positioned));
+        }
+
+        positioned_shapes
+    }
+}

--- a/scene/src/objects.rs
+++ b/scene/src/objects.rs
@@ -54,11 +54,11 @@ impl PositionedShape {
 #[derive(Debug, Clone)]
 pub struct Position {
     pub parent: Option<Handle<Position>>,
-    pub matrix: Matrix,
+    pub matrix: Handle<Matrix>,
 }
 
-impl From<Matrix> for Position {
-    fn from(matrix: Matrix) -> Self {
+impl From<Handle<Matrix>> for Position {
+    fn from(matrix: Handle<Matrix>) -> Self {
         Position {
             parent: None,
             matrix,
@@ -87,9 +87,9 @@ pub struct PositionRenderObj {
     pub matrix: Id,
 }
 
-pub type Matrix = Handle<geometry::Matrix4>;
+pub type Matrix = geometry::Matrix4;
 
-impl Object for geometry::Matrix4 {
+impl Object for Matrix {
     type Keep = ();
     type Change = Self;
 


### PR DESCRIPTION
This PR implements matrix chains that should allow a greater degree of positioning objects. A position is a combination parent position and a local matrix. 

At a later time, this might be used for matrix and higher level optimizations. For example, the renderer may decide to translate vertices instead of providing computed matrices to the shader.

The renderer uses an simple incremental evaluator to update only the final matrices. 

The incremental evaluator used is _not_ optimal in the sense that it has to touch all dependences in use. But it does guarantee that only the minimum required number of matrix multiplications are executed. The algorithm is inspired by https://dev.to/milomg/super-charging-fine-grained-reactive-performance-47ph. It time stamps all dependencies and closures and decides based on that if a recomputation is needed for the current state of the scene graph.
