### PR TITLE
Generic dependency tracking.

### DIFF
--- a/renderer/src/scene/dependency_resolver.rs
+++ b/renderer/src/scene/dependency_resolver.rs
@@ -6,14 +6,14 @@ use massive_scene::Id;
 /// Invoking this function ensures that the computed value `id` is up to date with its dependencies
 /// at `head_version`.
 ///
-/// We don't return a reference to the result here, because the borrow checker would make this
-/// recursive function invocation unnecessarily more complex.
+/// We don't return a reference to the computed value, because the borrow checker would not be
+/// able to unborrow `computed_storage` after a return (a current limitation).
 ///
 /// TODO: Unrecurse this. There might be degenerate cases of large dependency chains.
 pub fn resolve<Resolver: DependencyResolver>(
     head_version: Version,
     shared_storage: &Resolver::SharedStorage,
-    caches: &mut Resolver::ComputedStorage,
+    computed_storage: &mut Resolver::ComputedStorage,
     id: Id,
 ) where
     Computed<Resolver::Computed>: Default,
@@ -22,30 +22,30 @@ pub fn resolve<Resolver: DependencyResolver>(
     //
     // `get_or_default` must be used here. This is the only situation in which the cache may
     // need to be resized.
-    let computed = Resolver::computed_mut(caches, id);
-    if computed.validated_at == head_version {
+    if Resolver::computed_mut(computed_storage, id).validated_at == head_version {
         return;
     }
+
     // Save the current max dependencies version for later.
     //
     // In theory this could be overwritten if there are cycles in the dependency graph, but in
     // practice they are not (and everything may blow up anyway).
-    let computed_max_deps = computed.max_deps_version;
+    let computed_max_deps = Resolver::computed_mut(computed_storage, id).max_deps_version;
 
     let source = Resolver::source(shared_storage, id);
     let max_deps_version =
-        Resolver::resolve_dependencies(head_version, source, shared_storage, caches);
+        Resolver::resolve_dependencies(head_version, source, shared_storage, computed_storage);
 
     // If the max_deps_version is smaller or equal to the one of the computed value, the value is ok
     // and can be marked as validated at `head_version`.
     if max_deps_version <= computed_max_deps {
-        Resolver::computed_mut(caches, id).validated_at = head_version;
+        Resolver::computed_mut(computed_storage, id).validated_at = head_version;
         return;
     }
 
     // Compute a new value and store it.
-    let new_value = Resolver::compute(shared_storage, caches, source);
-    *Resolver::computed_mut(caches, id) = Computed {
+    let new_value = Resolver::compute(shared_storage, computed_storage, source);
+    *Resolver::computed_mut(computed_storage, id) = Computed {
         validated_at: head_version,
         max_deps_version,
         value: new_value,

--- a/renderer/src/scene/dependency_resolver.rs
+++ b/renderer/src/scene/dependency_resolver.rs
@@ -1,0 +1,87 @@
+use super::versioning::{Computed, Version, Versioned};
+use massive_scene::Id;
+
+/// Resolve a computed value.
+///
+/// Invoking this function ensures that the computed value `id` is up to date with its dependencies
+/// at `head_version`.
+///
+/// We don't return a reference to the result here, because the borrow checker would make this
+/// recursive function invocation unnecessarily more complex.
+///
+/// TODO: Unrecurse this. There might be degenerate cases of large dependency chains.
+pub fn resolve<Resolver: DependencyResolver>(
+    head_version: Version,
+    shared_storage: &Resolver::SharedStorage,
+    caches: &mut Resolver::ComputedStorage,
+    id: Id,
+) where
+    Computed<Resolver::Computed>: Default,
+{
+    // Already validated at the latest version? Done.
+    //
+    // `get_or_default` must be used here. This is the only situation in which the cache may
+    // need to be resized.
+    let computed = Resolver::computed_mut(caches, id);
+    if computed.validated_at == head_version {
+        return;
+    }
+    // Save the current max dependencies version for later.
+    //
+    // In theory this could be overwritten if there are cycles in the dependency graph, but in
+    // practice they are not (and everything may blow up anyway).
+    let computed_max_deps = computed.max_deps_version;
+
+    let source = Resolver::source(shared_storage, id);
+    let max_deps_version =
+        Resolver::resolve_dependencies(head_version, source, shared_storage, caches);
+
+    // If the max_deps_version is smaller or equal to the one of the computed value, the value is ok
+    // and can be marked as validated at `head_version`.
+    if max_deps_version <= computed_max_deps {
+        Resolver::computed_mut(caches, id).validated_at = head_version;
+        return;
+    }
+
+    // Compute a new value and store it.
+    let new_value = Resolver::compute(shared_storage, caches, source);
+    *Resolver::computed_mut(caches, id) = Computed {
+        validated_at: head_version,
+        max_deps_version,
+        value: new_value,
+    };
+}
+
+pub trait DependencyResolver {
+    /// Type of the shared table storage.
+    type SharedStorage;
+    /// Type of the computed table storage.
+    type ComputedStorage;
+
+    /// The symmetric _versioned_ source value type. There must be a source value for every computed
+    /// value with the same id.
+    type Source;
+    /// The computed value type (must implement Default for now, use Option<> otherwise)
+    type Computed;
+
+    /// Retrieve a reference to the versioned source value.
+    fn source(scene: &Self::SharedStorage, id: Id) -> &Versioned<Self::Source>;
+
+    /// Make sure that all dependencies are up to date and return their maximum version.
+    fn resolve_dependencies(
+        head_version: Version,
+        source: &Versioned<Self::Source>,
+        shared: &Self::SharedStorage,
+        computed: &mut Self::ComputedStorage,
+    ) -> Version;
+
+    fn compute(
+        shared: &Self::SharedStorage,
+        computed: &Self::ComputedStorage,
+        source: &Self::Source,
+    ) -> Self::Computed;
+
+    fn computed_mut(computed: &mut Self::ComputedStorage, id: Id) -> &mut Computed<Self::Computed>
+    where
+        Computed<Self::Computed>: Default;
+}

--- a/renderer/src/scene/id_table.rs
+++ b/renderer/src/scene/id_table.rs
@@ -33,7 +33,7 @@ impl<T> IdTable<T> {
     /// Returns a reference to a value at `id`.
     ///
     /// May resize and create defaults.
-    pub fn get_or_default(&mut self, id: Id) -> &T
+    pub fn mut_or_default(&mut self, id: Id) -> &mut T
     where
         T: Default,
     {
@@ -42,7 +42,7 @@ impl<T> IdTable<T> {
             self.rows.resize_with(index + 1, || T::default())
         }
 
-        &self.rows[index]
+        &mut self.rows[index]
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &T> {

--- a/renderer/src/scene/mod.rs
+++ b/renderer/src/scene/mod.rs
@@ -157,7 +157,7 @@ trait DependencyResolver {
 
     fn compute(
         shared: &Self::SharedStorage,
-        computed: &mut Self::ComputedStorage,
+        computed: &Self::ComputedStorage,
         source: &Self::Source,
     ) -> Self::Computed;
 
@@ -213,7 +213,7 @@ impl DependencyResolver for PositionedMatrix {
         caches.positions_matrix.mut_or_default(id)
     }
 
-    fn compute(scene: &Scene, caches: &mut SceneCaches, source: &Self::Source) -> Self::Computed {
+    fn compute(scene: &Scene, caches: &SceneCaches, source: &Self::Source) -> Self::Computed {
         let (parent_id, matrix_id) = (source.parent, source.matrix);
         let local_matrix = &**scene.matrices.get_unwrapped(matrix_id);
         parent_id.map_or_else(

--- a/renderer/src/scene/mod.rs
+++ b/renderer/src/scene/mod.rs
@@ -117,7 +117,7 @@ fn resolve<Resolver: DependencyResolver>(
         Resolver::resolve_dependencies(head_version, source, shared_storage, caches);
 
     // If the max_deps_version is smaller or equal to the current one, the value is ok and can
-    // be marked as validated for this round.
+    // be marked as validated at `head_version`.
     if max_deps_version <= computed_max_deps {
         Resolver::computed_mut(caches, id).validated_at = head_version;
         return;
@@ -135,7 +135,6 @@ fn resolve<Resolver: DependencyResolver>(
 trait DependencyResolver {
     /// Type of the shared table storage.
     type SharedStorage;
-
     /// Type of the computed table storage.
     type ComputedStorage;
 

--- a/renderer/src/scene/mod.rs
+++ b/renderer/src/scene/mod.rs
@@ -1,11 +1,14 @@
 use std::{cell::RefCell, collections::HashMap};
 
 use euclid::num::Zero;
+
+use dependency_resolver::{resolve, DependencyResolver};
 use id_table::IdTable;
 use massive_geometry::Matrix4;
 use massive_scene::{Change, Id, PositionRenderObj, PositionedRenderShape, SceneChange, Shape};
 use versioning::{Computed, Version, Versioned};
 
+mod dependency_resolver;
 mod id_table;
 mod versioning;
 
@@ -79,91 +82,6 @@ impl Scene {
     fn resolve_positioned_matrix(&self, position_id: Id, caches: &mut SceneCaches) {
         resolve::<PositionedMatrix>(self.current_version, self, caches, position_id);
     }
-}
-
-/// Resolve a computed value.
-///
-/// Invoking this function ensures that the computed value `id` is up to date with its dependencies
-/// at `head_version`.
-///
-/// We don't return a reference to the result here, because the borrow checker would make this
-/// recursive function invocation unnecessarily more complex.
-///
-/// TODO: Unrecurse this. There might be degenerate cases of large dependency chains.
-fn resolve<Resolver: DependencyResolver>(
-    head_version: Version,
-    shared_storage: &Resolver::SharedStorage,
-    caches: &mut Resolver::ComputedStorage,
-    id: Id,
-) where
-    Computed<Resolver::Computed>: Default,
-{
-    // Already validated at the latest version? Done.
-    //
-    // `get_or_default` must be used here. This is the only situation in which the cache may
-    // need to be resized.
-    let computed = Resolver::computed_mut(caches, id);
-    if computed.validated_at == head_version {
-        return;
-    }
-    // Save the current max dependencies version for later.
-    //
-    // In theory this could be overwritten if there are cycles in the dependency graph, but in
-    // practice they are not (and everything may blow up anyway).
-    let computed_max_deps = computed.max_deps_version;
-
-    let source = Resolver::source(shared_storage, id);
-    let max_deps_version =
-        Resolver::resolve_dependencies(head_version, source, shared_storage, caches);
-
-    // If the max_deps_version is smaller or equal to the current one, the value is ok and can
-    // be marked as validated at `head_version`.
-    if max_deps_version <= computed_max_deps {
-        Resolver::computed_mut(caches, id).validated_at = head_version;
-        return;
-    }
-
-    // Compute a new value and store it.
-    let new_value = Resolver::compute(shared_storage, caches, source);
-    *Resolver::computed_mut(caches, id) = Computed {
-        validated_at: head_version,
-        max_deps_version,
-        value: new_value,
-    };
-}
-
-trait DependencyResolver {
-    /// Type of the shared table storage.
-    type SharedStorage;
-    /// Type of the computed table storage.
-    type ComputedStorage;
-
-    /// The symmetric _versioned_ source value type. There must be a source value for every computed
-    /// value with the same id.
-    type Source;
-    /// The computed value type (must implement Default for now, use Option<> otherwise)
-    type Computed;
-
-    /// Retrieve a reference to the versioned source value.
-    fn source(scene: &Self::SharedStorage, id: Id) -> &Versioned<Self::Source>;
-
-    /// Make sure that all dependencies are up to date and return their maximum version.
-    fn resolve_dependencies(
-        head_version: Version,
-        source: &Versioned<Self::Source>,
-        shared: &Self::SharedStorage,
-        computed: &mut Self::ComputedStorage,
-    ) -> Version;
-
-    fn compute(
-        shared: &Self::SharedStorage,
-        computed: &Self::ComputedStorage,
-        source: &Self::Source,
-    ) -> Self::Computed;
-
-    fn computed_mut(computed: &mut Self::ComputedStorage, id: Id) -> &mut Computed<Self::Computed>
-    where
-        Computed<Self::Computed>: Default;
 }
 
 /// The dependency resolver for finally positioned matrix.


### PR DESCRIPTION
The goal of this PR is to make dependency tracking applicable in a broader context. For example to update buffers, etc.