### PR TITLE
Log example: Center animation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ flo_curves = "0.7.2"
 static_assertions = "1.1.0"
 itertools = "0.12.1"
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing-flame = "0.2.0"
 tracing-chrome = "0.7.2"
 chrono = "0.4.38"

--- a/examples/logs/examples/logs.rs
+++ b/examples/logs/examples/logs.rs
@@ -338,9 +338,10 @@ impl Logs {
         //
         // OO: Or, we introduce another handle type that stores the matrix locally and
         // compares it _before_ uploading.
-        let new_matrix = self
-            .application
-            .matrix((self.page_width, self.page_height.value() as u32));
+        let new_matrix = self.application.matrix((
+            self.page_width,
+            1u32, /* self.page_height.value() as u32*/
+        ));
         self.page_matrix.update_if_changed(new_matrix);
         self.director.action()?;
         Ok(())

--- a/examples/logs/examples/logs.rs
+++ b/examples/logs/examples/logs.rs
@@ -221,11 +221,7 @@ impl Logs {
         // See if some lines need to be faded out.
 
         {
-            let overhead_lines = if self.lines.len() > MAX_LINES {
-                self.lines.len() - MAX_LINES
-            } else {
-                0
-            };
+            let overhead_lines = self.lines.len().saturating_sub(MAX_LINES);
 
             for line in self.lines.iter_mut().take(overhead_lines) {
                 if !line.fading_out {


### PR DESCRIPTION
This MR smoothens the animation of the log example. It always keeps the inner lines stable while pushing the fading lines out of the center areas.