### PR TITLE
Replace Director with Scene

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ A 3D visualization of a markdown file (basically my CV). Layouted using [inlyne]
 cargo run --release --example markdown
 ```
 
-## Acronyms used in the code.
+## Acronyms and contexts used in the code.
 
 - DR: Decision Record.
-- OO: Optimization Opportunity
-- NI: Naming Issue
-- DI: Design Issue (e.g. something does not seem to belong here)
+- OO: Optimization Opportunity (replacement: `Optimization:`)
+- NI: Naming Issue (replacement: `Naming:`)
+- DI: Design Issue (e.g. something does not seem to belong here) (replacement `Architecture:`)
+- Ergonomics: API surface ergonomics, directly related to programmer happiness.

--- a/examples/hello/examples/hello.rs
+++ b/examples/hello/examples/hello.rs
@@ -2,8 +2,6 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use cosmic_text as text;
-use massive_scene::legacy;
-use shared::positioning;
 use text::FontSystem;
 use winit::{
     dpi::LogicalSize,
@@ -12,8 +10,10 @@ use winit::{
 };
 
 use massive_geometry::{Camera, Color, Identity, Matrix4, Vector3};
+use massive_scene::{legacy, Scene};
 use massive_shapes::{GlyphRun, GlyphRunMetrics, GlyphRunShape, Shape, TextWeight};
 use massive_shell::{shell, ApplicationContext};
+use shared::positioning;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -36,16 +36,16 @@ async fn application(mut ctx: ApplicationContext) -> Result<()> {
 
     let window = ctx.new_window(LogicalSize::new(1280, 800), None).await?;
 
-    let (mut renderer, mut director) = window
+    let mut renderer = window
         .new_renderer(font_system, camera, window.inner_size())
         .await?;
 
-    let _visuals = legacy::into_visuals(&mut director, shapes);
-    director.action()?;
+    let scene = Scene::new();
+    let _visuals = legacy::into_visuals(&scene, shapes);
 
     loop {
         let event = ctx.wait_for_shell_event(&mut renderer).await?;
-        let cycle = ctx.begin_update_cycle(&mut renderer, Some(&event))?;
+        let cycle = ctx.begin_update_cycle(&scene, &mut renderer, Some(&event))?;
 
         let Some(window_event) = event.window_event_for_id(window.id()) else {
             continue;

--- a/examples/logs/examples/logs.rs
+++ b/examples/logs/examples/logs.rs
@@ -23,7 +23,7 @@ use winit::{
 
 use massive_animation::{Interpolation, Timeline};
 use massive_geometry::{Camera, Identity, Vector3};
-use massive_scene::{Director, Handle, Location, Matrix, Shape, Visual};
+use massive_scene::{Handle, Location, Matrix, Scene, Shape, Visual};
 use massive_shell::{
     application_context::UpdateCycle,
     shell::{self, ShellEvent},
@@ -101,26 +101,25 @@ async fn logs(mut receiver: UnboundedReceiver<Vec<u8>>, mut ctx: ApplicationCont
         Camera::new((0.0, 0.0, camera_distance), (0.0, 0.0, 0.0))
     };
 
-    let (mut renderer, director) = window
+    let mut renderer = window
         .new_renderer(font_system.clone(), camera, window.inner_size())
         .await?;
 
-    let mut logs = Logs::new(&mut ctx, font_system, director);
+    let mut logs = Logs::new(&mut ctx, font_system);
+    let scene = Scene::new();
 
     // Application
 
     loop {
-        logs.director.action()?;
-
         select! {
             Some(bytes) = receiver.recv() => {
-                let cycle = ctx.begin_update_cycle(&mut renderer, None)?;
+                let cycle = ctx.begin_update_cycle(&scene, &mut renderer, None)?;
                 logs.add_line(&cycle, &bytes);
                 logs.update_layout()?;
             },
 
             Ok(event) = ctx.wait_for_shell_event(&mut renderer) => {
-                let _cycle = ctx.begin_update_cycle(&mut renderer, Some(&event))?;
+                let _cycle = ctx.begin_update_cycle(&scene, &mut renderer, Some(&event))?;
                 if logs.handle_shell_event(event, &window) == UpdateResponse::Exit {
                     return Ok(())
                 }
@@ -131,7 +130,6 @@ async fn logs(mut receiver: UnboundedReceiver<Vec<u8>>, mut ctx: ApplicationCont
 
 struct Logs {
     font_system: Arc<Mutex<FontSystem>>,
-    director: Director,
 
     application: Application,
 
@@ -147,24 +145,21 @@ struct Logs {
 }
 
 impl Logs {
-    fn new(
-        ctx: &mut ApplicationContext,
-        font_system: Arc<Mutex<FontSystem>>,
-        mut director: Director,
-    ) -> Self {
+    fn new(ctx: &mut ApplicationContext, font_system: Arc<Mutex<FontSystem>>) -> Self {
         let page_width = 1280u32;
         let application = Application::default();
         let current_matrix = application.matrix((page_width, page_width));
-        let page_matrix = director.stage(current_matrix);
-        let page_location = director.stage(Location::from(page_matrix.clone()));
+        let scene = Scene::new();
+        let page_matrix = scene.stage(current_matrix);
+        let page_location = scene.stage(Location::from(page_matrix.clone()));
 
         let vertical_center = ctx.timeline(0.0);
 
         // We move up the lines by their top position.
-        let vertical_center_matrix = director.stage(Matrix::identity());
+        let vertical_center_matrix = scene.stage(Matrix::identity());
 
         // Final position for all lines (runs are y-translated, but only increasing).
-        let location = director.stage(Location {
+        let location = scene.stage(Location {
             parent: Some(page_location),
             matrix: vertical_center_matrix.clone(),
         });
@@ -173,7 +168,6 @@ impl Logs {
 
         Self {
             font_system,
-            director,
             application,
             page_matrix,
             page_width,
@@ -196,7 +190,7 @@ impl Logs {
         let glyph_runs: Vec<Shape> = glyph_runs.into_iter().map(|run| run.into()).collect();
 
         let line = Visual::new(self.location.clone(), glyph_runs);
-        let line = self.director.stage(line);
+        let line = cycle.scene().stage(line);
 
         self.lines.push_back(LogLine {
             top: self.next_line_top,

--- a/examples/logs/examples/logs.rs
+++ b/examples/logs/examples/logs.rs
@@ -105,8 +105,8 @@ async fn logs(mut receiver: UnboundedReceiver<Vec<u8>>, mut ctx: ApplicationCont
         .new_renderer(font_system.clone(), camera, window.inner_size())
         .await?;
 
-    let mut logs = Logs::new(&mut ctx, font_system);
     let scene = Scene::new();
+    let mut logs = Logs::new(&mut ctx, &scene, font_system);
 
     // Application
 
@@ -145,11 +145,14 @@ struct Logs {
 }
 
 impl Logs {
-    fn new(ctx: &mut ApplicationContext, font_system: Arc<Mutex<FontSystem>>) -> Self {
+    fn new(
+        ctx: &mut ApplicationContext,
+        scene: &Scene,
+        font_system: Arc<Mutex<FontSystem>>,
+    ) -> Self {
         let page_width = 1280u32;
         let application = Application::default();
         let current_matrix = application.matrix((page_width, page_width));
-        let scene = Scene::new();
         let page_matrix = scene.stage(current_matrix);
         let page_location = scene.stage(Location::from(page_matrix.clone()));
 

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -142,8 +142,8 @@ impl Renderer {
         Ok(())
     }
 
-    /// We want this separate from [`Self::render_and_present`], because of the timing impliciation. In any
-    /// VSync mode, this blocks until the current frame is presented.
+    /// We want this separate from [`Self::render_and_present`], because of the timing impliciation.
+    /// In any VSync mode, this blocks until the current frame is presented.
     ///
     /// This is `&mut self`, because it might call into [`Self::reconfigure_surface`] when the
     /// surface is lost.

--- a/scene/src/change.rs
+++ b/scene/src/change.rs
@@ -1,26 +1,13 @@
-use std::{any::TypeId, mem, ops::DerefMut, sync::Mutex};
+use std::any::TypeId;
 
 use derive_more::From;
+use massive_geometry::Matrix4;
 
 use crate::{Id, Location, LocationRenderObj, Visual, VisualRenderObj};
-use massive_geometry as geometry;
-
-#[derive(Debug, Default)]
-pub struct ChangeTracker(Mutex<Vec<SceneChange>>);
-
-impl ChangeTracker {
-    pub fn push(&self, change: impl Into<SceneChange>) {
-        self.0.lock().unwrap().push(change.into());
-    }
-
-    pub(crate) fn take_all(&self) -> Vec<SceneChange> {
-        mem::take(self.0.lock().unwrap().deref_mut())
-    }
-}
 
 #[derive(Debug, From)]
 pub enum SceneChange {
-    Matrix(Change<geometry::Matrix4>),
+    Matrix(Change<Matrix4>),
     Location(Change<LocationRenderObj>),
     Visual(Change<VisualRenderObj>),
 }
@@ -28,9 +15,7 @@ pub enum SceneChange {
 impl SceneChange {
     pub fn destructive_change(&self) -> Option<(TypeId, Id)> {
         match self {
-            SceneChange::Matrix(Change::Delete(id)) => {
-                Some((TypeId::of::<geometry::Matrix4>(), *id))
-            }
+            SceneChange::Matrix(Change::Delete(id)) => Some((TypeId::of::<Matrix4>(), *id)),
             SceneChange::Visual(Change::Delete(id)) => Some((TypeId::of::<Visual>(), *id)),
             SceneChange::Location(Change::Delete(id)) => Some((TypeId::of::<Location>(), *id)),
             // .. to prevent missing new cases:

--- a/scene/src/change_collector.rs
+++ b/scene/src/change_collector.rs
@@ -1,0 +1,20 @@
+use std::{mem, ops::DerefMut, sync::Mutex};
+
+use crate::SceneChange;
+
+#[derive(Debug, Default)]
+pub struct ChangeCollector(Mutex<Vec<SceneChange>>);
+
+impl ChangeCollector {
+    pub fn push(&self, change: impl Into<SceneChange>) {
+        self.0.lock().unwrap().push(change.into());
+    }
+
+    pub fn push_many(&self, changes: Vec<SceneChange>) {
+        self.0.lock().unwrap().extend(changes);
+    }
+
+    pub fn take_all(&self) -> Vec<SceneChange> {
+        mem::take(self.0.lock().unwrap().deref_mut())
+    }
+}

--- a/scene/src/handle.rs
+++ b/scene/src/handle.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use crate::{Change, ChangeTracker, Id, SceneChange};
+use crate::{Change, ChangeCollector, Id, SceneChange};
 
 pub trait Object: Sized + fmt::Debug
 where
@@ -39,7 +39,7 @@ impl<T: Object> Handle<T>
 where
     SceneChange: From<Change<T::Change>>,
 {
-    pub(crate) fn new(id: Id, value: T, change_tracker: Arc<ChangeTracker>) -> Self {
+    pub(crate) fn new(id: Id, value: T, change_tracker: Arc<ChangeCollector>) -> Self {
         let uploaded = T::to_change(&value);
         change_tracker.push(Change::Create(id, uploaded));
 
@@ -92,7 +92,7 @@ where
     SceneChange: From<Change<T::Change>>,
 {
     id: Id,
-    change_tracker: Arc<ChangeTracker>,
+    change_tracker: Arc<ChangeCollector>,
     // OO: Some values might be too large to be duplicated between the application and the renderer.
     value: Mutex<T>,
 }

--- a/scene/src/id.rs
+++ b/scene/src/id.rs
@@ -2,6 +2,9 @@ use derive_more::Deref;
 
 /// An identifier that can be used to index into rows to allow fast id associative storage and
 /// retrieval of objects.
+///
+/// Ids start at 0 and their maximum value are never greater than the number of ids acquired. This
+/// makes them optimal for using them as storage indices.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deref)]
 pub struct Id(usize);
 

--- a/scene/src/id.rs
+++ b/scene/src/id.rs
@@ -6,13 +6,13 @@ use derive_more::Deref;
 pub struct Id(usize);
 
 #[derive(Debug, Default)]
-pub struct IdGen {
+pub struct Generator {
     next_id: usize,
     free_list: Vec<usize>,
 }
 
-impl IdGen {
-    pub fn allocate(&mut self) -> Id {
+impl Generator {
+    pub fn acquire(&mut self) -> Id {
         if let Some(free) = self.free_list.pop() {
             return Id(free);
         }
@@ -23,7 +23,7 @@ impl IdGen {
         Id(this_id)
     }
 
-    pub fn free(&mut self, id: Id) {
+    pub fn release(&mut self, id: Id) {
         self.free_list.push(id.0);
     }
 }

--- a/scene/src/objects.rs
+++ b/scene/src/objects.rs
@@ -100,12 +100,12 @@ impl Object for Matrix {
 
 pub mod legacy {
     use super::Handle;
-    use crate::{Director, Location, Visual};
+    use crate::{Location, Scene, Visual};
     use massive_geometry::Matrix4;
     use massive_shapes::{GlyphRunShape, QuadsShape, Shape};
     use std::{collections::HashMap, sync::Arc};
 
-    pub fn into_visuals(director: &mut Director, shapes: Vec<Shape>) -> Vec<Handle<Visual>> {
+    pub fn into_visuals(director: &Scene, shapes: Vec<Shape>) -> Vec<Handle<Visual>> {
         let mut location_handles: HashMap<*const Matrix4, Handle<Location>> = HashMap::new();
         let mut visuals = Vec::with_capacity(shapes.len());
 

--- a/scene/src/scene.rs
+++ b/scene/src/scene.rs
@@ -48,7 +48,7 @@ impl Scene {
     pub fn take_changes(&self) -> Result<Vec<SceneChange>> {
         let changes = self.change_tracker.take_all();
 
-        // Short circute, to prevent locking the id generator.
+        // Short circuit, to prevent locking the id generator.
         if changes.is_empty() {
             return Ok(Vec::new());
         }

--- a/scene/src/scene.rs
+++ b/scene/src/scene.rs
@@ -1,0 +1,69 @@
+use std::{
+    any::TypeId,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::Result;
+
+use crate::{
+    type_id_generator::TypeIdGenerator, Change, ChangeCollector, Handle, Object, SceneChange,
+};
+
+/// A scene is the only direct connection of actual contents to the renderer. It tracks all the
+/// changes to scene graph and uploads it when an update cycle ends.
+///
+/// A scene does not have direct observable changes, so it can always be shared and used for staging
+/// objects onto it.
+#[derive(Debug, Default)]
+pub struct Scene {
+    // Each type requires its own id generator to ensure that the generated ids are contiguous
+    // within that type.
+    //
+    // Robustness: Id generation should probably be done somewhere else to enable multiple scenes?
+    id_generator: Mutex<TypeIdGenerator>,
+    // This tracks all changes from staging, changing the the values in the handles, and dropping them.
+    //
+    // Shared because the Handles need to push changes on drop.
+    change_tracker: Arc<ChangeCollector>,
+}
+
+impl Scene {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Put an object on the stage.
+    pub fn stage<T: Object + 'static>(&self, value: T) -> Handle<T>
+    where
+        SceneChange: From<Change<T::Change>>,
+    {
+        let tid = TypeId::of::<T>();
+        // Architecture: Can't we put the TypeIdGenerator and the ChangeTracker together to remove
+        // the two locks here (second one is in Handle::new)?
+        let id = self.id_generator.lock().unwrap().acquire(tid);
+        Handle::new(id, value, self.change_tracker.clone())
+    }
+
+    // Take the changes that need to be sent to the renderer and release the ids in the process.
+    pub fn take_changes(&self) -> Result<Vec<SceneChange>> {
+        let changes = self.change_tracker.take_all();
+
+        // Short circute, to prevent locking the id generator.
+        if changes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Optimization: May not lock the id generator if there are no destructive changes.
+        let mut id_gen = self.id_generator.lock().unwrap();
+
+        // Free up all deleted ids (this is done immediately for now, but may be later done in the
+        // renderer, for example to keep ids alive until animations are finished or cached resources
+        // are cleaned up)
+        for (type_id, id) in changes.iter().flat_map(|sc| sc.destructive_change()) {
+            // TODO: order by TypeId first?
+            id_gen.release(type_id, id);
+        }
+
+        Ok(changes)
+    }
+}

--- a/scene/src/type_id_generator.rs
+++ b/scene/src/type_id_generator.rs
@@ -1,0 +1,22 @@
+use std::{any::TypeId, collections::HashMap};
+
+use crate::{id::Generator, Id};
+
+/// A (sharable) generator for ids per type.
+#[derive(Debug, Default)]
+pub struct TypeIdGenerator {
+    ids: HashMap<TypeId, Generator>,
+}
+
+impl TypeIdGenerator {
+    pub fn acquire(&mut self, tid: TypeId) -> Id {
+        self.ids.entry(tid).or_default().acquire()
+    }
+
+    pub fn release(&mut self, tid: TypeId, id: Id) {
+        self.ids
+            .get_mut(&tid)
+            .expect("Releasing an id failed, generator missing for type")
+            .release(id);
+    }
+}

--- a/shell/src/shell_window.rs
+++ b/shell/src/shell_window.rs
@@ -13,7 +13,6 @@ use winit::{
 
 use crate::{shell::ShellRequest, window_renderer::WindowRenderer, AsyncWindowRenderer};
 use massive_geometry::Camera;
-use massive_scene::Director;
 
 pub struct ShellWindow {
     /// `Arc` because this is shared with the renderer because it needs to invoke request_redraw(), too.
@@ -31,7 +30,7 @@ impl ShellWindow {
         // Use a rect here to place the renderer on the window.
         // (But what about resizes then?)
         initial_size: PhysicalSize<u32>,
-    ) -> Result<(AsyncWindowRenderer, Director)> {
+    ) -> Result<AsyncWindowRenderer> {
         let instance_and_surface = self
             .new_instance_and_surface(
                 InstanceDescriptor::default(),
@@ -60,7 +59,7 @@ impl ShellWindow {
 
         // DI: If we can access the ShellWindow, we don't need a clone of font_system or
         // event_loop_proxy here.
-        let (window_renderer, director) = WindowRenderer::new(
+        let window_renderer = WindowRenderer::new(
             self.window.clone(),
             instance,
             surface,
@@ -71,7 +70,7 @@ impl ShellWindow {
         .await?;
 
         let async_window_renderer = AsyncWindowRenderer::new(window_renderer);
-        Ok((async_window_renderer, director))
+        Ok(async_window_renderer)
     }
 
     /// Helper to create instance and surface.

--- a/shell/src/window_renderer.rs
+++ b/shell/src/window_renderer.rs
@@ -21,7 +21,7 @@ pub struct WindowRenderer {
     window: Arc<Window>,
     font_system: Arc<Mutex<FontSystem>>,
     camera: Camera,
-    scene_changes: Arc<ChangeCollector>,
+    change_collector: Arc<ChangeCollector>,
     renderer: Renderer,
 }
 
@@ -103,7 +103,7 @@ impl WindowRenderer {
             window: window.clone(),
             font_system,
             camera,
-            scene_changes: Arc::new(ChangeCollector::default()),
+            change_collector: Arc::new(ChangeCollector::default()),
             renderer,
         };
 
@@ -119,7 +119,7 @@ impl WindowRenderer {
     }
 
     pub fn change_collector(&self) -> &Arc<ChangeCollector> {
-        &self.scene_changes
+        &self.change_collector
     }
 
     // DI: If the renderer does culling, we need to move the camera (or at least the view matrix) into the renderer, and
@@ -175,7 +175,7 @@ impl WindowRenderer {
     pub(crate) fn apply_scene_changes_and_prepare_presentation(
         &mut self,
     ) -> Result<wgpu::SurfaceTexture> {
-        let changes = self.scene_changes.take_all();
+        let changes = self.change_collector.take_all();
 
         {
             let mut font_system = self.font_system.lock().unwrap();

--- a/shell/src/window_renderer.rs
+++ b/shell/src/window_renderer.rs
@@ -1,12 +1,7 @@
-use std::{
-    mem,
-    ops::DerefMut,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 use log::info;
-use massive_scene::SceneChange;
 use wgpu::{PresentMode, Surface, TextureFormat};
 use winit::{
     dpi::PhysicalSize,
@@ -17,6 +12,7 @@ use winit::{
 use cosmic_text::FontSystem;
 use massive_geometry::{scalar, Camera, Matrix4};
 use massive_renderer::Renderer;
+use massive_scene::ChangeCollector;
 
 const Z_RANGE: (scalar, scalar) = (0.1, 100.0);
 const DESIRED_MAXIMUM_FRAME_LATENCY: u32 = 1;
@@ -25,7 +21,7 @@ pub struct WindowRenderer {
     window: Arc<Window>,
     font_system: Arc<Mutex<FontSystem>>,
     camera: Camera,
-    scene_changes: Arc<Mutex<Vec<SceneChange>>>,
+    scene_changes: Arc<ChangeCollector>,
     renderer: Renderer,
 }
 
@@ -38,7 +34,7 @@ impl WindowRenderer {
         camera: Camera,
         // TODO: use a rect here to be able to position the renderer!
         initial_size: PhysicalSize<u32>,
-    ) -> Result<(WindowRenderer, massive_scene::Director)> {
+    ) -> Result<WindowRenderer> {
         info!("Getting adapter");
 
         let adapter = instance
@@ -103,37 +99,18 @@ impl WindowRenderer {
         surface.configure(&device, &surface_config);
         let renderer = Renderer::new(device, queue, surface, surface_config);
 
-        let scene_changes = Arc::new(Mutex::new(Vec::new()));
-
         let window_renderer = WindowRenderer {
             window: window.clone(),
             font_system,
             camera,
-            scene_changes: scene_changes.clone(),
+            scene_changes: Arc::new(ChangeCollector::default()),
             renderer,
         };
 
-        let window = window.clone();
-
-        let director = massive_scene::Director::new(move |changes| {
-            // Since we are the only one pushing to the renderer, we can invoke a request redraw
-            // only once as soon `scene_changes` switch from empty to non-empty.
-            let request_redraw = {
-                let mut scene_changes = scene_changes.lock().unwrap();
-                let was_empty = scene_changes.is_empty();
-                scene_changes.extend(changes);
-                was_empty && !scene_changes.is_empty()
-            };
-            if request_redraw {
-                window.request_redraw();
-            }
-            Ok(())
-        });
-
-        Ok((window_renderer, director))
+        Ok(window_renderer)
     }
 
-    pub fn id(&self) -> WindowId {
+    pub fn window_id(&self) -> WindowId {
         self.window.id()
     }
 
@@ -141,10 +118,15 @@ impl WindowRenderer {
         &self.font_system
     }
 
+    pub fn change_collector(&self) -> &Arc<ChangeCollector> {
+        &self.scene_changes
+    }
+
     // DI: If the renderer does culling, we need to move the camera (or at least the view matrix) into the renderer, and
     // perhaps schedule updates using the director.
     pub fn update_camera(&mut self, camera: Camera) {
         self.camera = camera;
+        // Robustness: We probably should draw this directly in the end of the next cycle.
         self.window.request_redraw();
     }
 
@@ -193,13 +175,14 @@ impl WindowRenderer {
     pub(crate) fn apply_scene_changes_and_prepare_presentation(
         &mut self,
     ) -> Result<wgpu::SurfaceTexture> {
-        let changes = mem::take(self.scene_changes.lock().unwrap().deref_mut());
+        let changes = self.scene_changes.take_all();
 
         {
             let mut font_system = self.font_system.lock().unwrap();
             self.renderer.apply_changes(&mut font_system, changes)?;
         }
 
+        // Important: This blocks in VSync modes until the previous frame is presented.
         // Robustness: Learn about how to recover from specific `SurfaceError`s errors here
         // `get_current_texture()` tries once.
         let texture = self


### PR DESCRIPTION
This PR replaces the Director with Scene with the additional following changes:

- Directly pushes scene changes to the renderer instead of going throw request_redraw() on the window.
- Removes the action() method. This is not needed anymore, because all changes are committed at the end of an update cycle.
