### PR TITLE
Lock step rendering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 
 members = [
     "animation",
@@ -16,6 +16,9 @@ exclude = [
     "examples/dist",
     "examples/code/rust-analyzer"
 ]
+
+[workspace.package]
+edition = "2024"
 
 [workspace.metadata]
 # For trunk

--- a/examples/code/Cargo.toml
+++ b/examples/code/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dev-dependencies]
 

--- a/examples/code/examples/code-viewer.rs
+++ b/examples/code/examples/code-viewer.rs
@@ -1,13 +1,13 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
-use cosmic_text::{fontdb, FontSystem};
+use cosmic_text::{FontSystem, fontdb};
 use tracing::info;
 use winit::dpi::LogicalSize;
 
 use massive_geometry::{Camera, SizeI};
 use massive_scene::{Scene, Visual};
-use massive_shell::{shell, ApplicationContext};
+use massive_shell::{ApplicationContext, shell};
 use shared::{
     application::{Application, UpdateResponse},
     attributed_text::{self, AttributedText},

--- a/examples/code/examples/code.rs
+++ b/examples/code/examples/code.rs
@@ -9,9 +9,9 @@ use std::{
 use anyhow::Result;
 use base_db::{RootQueryDb, SourceDatabase};
 use chrono::{DateTime, Local};
-use cosmic_text::{fontdb, FontSystem};
+use cosmic_text::{FontSystem, fontdb};
 use tracing::info;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
 use winit::dpi::LogicalSize;
 
 use hir::EditionedFileId;
@@ -27,7 +27,7 @@ use vfs::VfsPath;
 use massive_geometry::{Camera, Color, SizeI};
 use massive_scene::{Scene, Visual};
 use massive_shapes::TextWeight;
-use massive_shell::{shell, ApplicationContext};
+use massive_shell::{ApplicationContext, shell};
 use shared::{
     application::{Application, UpdateResponse},
     attributed_text::{self, AttributedText, TextAttribute},

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dev-dependencies]
 shared = { path = "../shared" }

--- a/examples/hello/examples/hello.rs
+++ b/examples/hello/examples/hello.rs
@@ -10,9 +10,9 @@ use winit::{
 };
 
 use massive_geometry::{Camera, Color, Identity, Matrix4, Vector3};
-use massive_scene::{legacy, Scene};
+use massive_scene::{Scene, legacy};
 use massive_shapes::{GlyphRun, GlyphRunMetrics, GlyphRunShape, Shape, TextWeight};
-use massive_shell::{shell, ApplicationContext};
+use massive_shell::{ApplicationContext, shell};
 use shared::positioning;
 
 #[tokio::main]
@@ -91,11 +91,13 @@ fn render(font_system: &mut FontSystem, str: &str) -> Vec<Shape> {
 
     glyph_run.translation = center_translation;
 
-    let shapes = vec![GlyphRunShape {
-        model_matrix: Matrix4::identity().into(),
-        run: glyph_run,
-    }
-    .into()];
+    let shapes = vec![
+        GlyphRunShape {
+            model_matrix: Matrix4::identity().into(),
+            run: glyph_run,
+        }
+        .into(),
+    ];
 
     shapes
 }

--- a/examples/logs/Cargo.toml
+++ b/examples/logs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "logs"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 termwiz = "0.23.3"

--- a/examples/logs/examples/logs.rs
+++ b/examples/logs/examples/logs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::Result;
-use cosmic_text::{fontdb, FontSystem};
+use cosmic_text::{FontSystem, fontdb};
 use log::{debug, warn};
 use termwiz::escape;
 use tokio::{
@@ -14,7 +14,7 @@ use tokio::{
     sync::mpsc::{self, UnboundedReceiver},
 };
 use tracing_subscriber::{
-    filter, fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
+    EnvFilter, Layer, filter, fmt, layer::SubscriberExt, util::SubscriberInitExt,
 };
 use winit::{
     dpi::LogicalSize,
@@ -25,9 +25,9 @@ use massive_animation::{Interpolation, Timeline};
 use massive_geometry::{Camera, Identity, Vector3};
 use massive_scene::{Handle, Location, Matrix, Scene, Shape, Visual};
 use massive_shell::{
+    ApplicationContext, ShellWindow,
     application_context::UpdateCycle,
     shell::{self, ShellEvent},
-    ApplicationContext, ShellWindow,
 };
 
 use logs::terminal::{self, color_schemes};

--- a/examples/logs/src/terminal/color_schemes.rs
+++ b/examples/logs/src/terminal/color_schemes.rs
@@ -14,7 +14,7 @@ pub struct Primary {
 }
 
 pub mod light {
-    use super::{ac, rgb, Primary, Scheme};
+    use super::{Primary, Scheme, ac, rgb};
 
     pub const PENCIL: Scheme = Scheme {
         primary: Primary {

--- a/examples/logs/src/terminal/text_attributor.rs
+++ b/examples/logs/src/terminal/text_attributor.rs
@@ -3,10 +3,10 @@ use std::{iter, ops::Range};
 use termwiz::{
     cell::Intensity,
     color::ColorSpec,
-    escape::{self, csi::Sgr, Action, ControlCode, CSI},
+    escape::{self, Action, CSI, ControlCode, csi::Sgr},
 };
 
-use crate::terminal::{color_schemes, Rgb};
+use crate::terminal::{Rgb, color_schemes};
 use massive_geometry::Color;
 use massive_shapes::TextWeight;
 use shared::attributed_text::TextAttribute;

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "markdown"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+
+[profile.release]
+panic = "abort"
+
+[profile.dev]
+panic = "abort"
 
 [dev-dependencies]
 shared = { path = "../shared" }

--- a/examples/markdown/examples/emojis.rs
+++ b/examples/markdown/examples/emojis.rs
@@ -7,20 +7,20 @@ use std::{
 use anyhow::{Context, Result};
 use cosmic_text::FontSystem;
 use inlyne::{
+    Element,
     color::Theme,
     interpreter::HtmlInterpreter,
     opts::ResolvedTheme,
-    positioner::{Positioned, Positioner, DEFAULT_MARGIN},
+    positioner::{DEFAULT_MARGIN, Positioned, Positioner},
     text::{CachedTextArea, TextCache, TextSystem},
-    utils::{markdown_to_html, Rect},
-    Element,
+    utils::{Rect, markdown_to_html},
 };
 use log::info;
 use winit::dpi::LogicalSize;
 
 use massive_geometry::{Camera, SizeI, Vector3};
 use massive_scene::{Scene, Visual};
-use massive_shell::{shell, ApplicationContext};
+use massive_shell::{ApplicationContext, shell};
 use shared::{
     application::{Application, UpdateResponse},
     positioning,
@@ -266,10 +266,10 @@ mod tests {
 
     #[test]
     fn test_color_emoji_font() {
+        use swash::FontRef;
         use swash::scale::ScaleContext;
         use swash::scale::*;
         use swash::zeno;
-        use swash::FontRef;
         use zeno::Vector;
 
         let font_data = include_bytes!("fonts/NotoColorEmoji-Regular.ttf");

--- a/examples/markdown/examples/markdown.rs
+++ b/examples/markdown/examples/markdown.rs
@@ -6,24 +6,24 @@ use std::{
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Local};
-use cosmic_text::{fontdb, FontSystem};
+use cosmic_text::{FontSystem, fontdb};
 use inlyne::{
+    Element,
     color::Theme,
     interpreter::HtmlInterpreter,
     opts::ResolvedTheme,
-    positioner::{Positioned, Positioner, DEFAULT_MARGIN},
+    positioner::{DEFAULT_MARGIN, Positioned, Positioner},
     text::{CachedTextArea, TextCache, TextSystem},
-    utils::{markdown_to_html, Rect},
-    Element,
+    utils::{Rect, markdown_to_html},
 };
 use log::info;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
 use winit::dpi::PhysicalSize;
 
 use massive_geometry::{Camera, SizeI, Vector3};
 use massive_scene::{Scene, Visual};
 use massive_shapes::GlyphRun;
-use massive_shell::{shell, ApplicationContext};
+use massive_shell::{ApplicationContext, shell};
 use shared::{
     application::{Application, UpdateResponse},
     fonts, positioning,

--- a/examples/shared/Cargo.toml
+++ b/examples/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shared"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/examples/syntax/Cargo.toml
+++ b/examples/syntax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "syntax"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dev-dependencies]
 shared = { path = "../shared" }

--- a/examples/syntax/examples/syntax.rs
+++ b/examples/syntax/examples/syntax.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
-use cosmic_text::{fontdb, FontSystem};
+use cosmic_text::{FontSystem, fontdb};
 use syntect::{
     easy::HighlightLines,
     highlighting::{FontStyle, Style, ThemeSet},
@@ -13,7 +13,7 @@ use winit::dpi::LogicalSize;
 use massive_geometry::{Camera, Color};
 use massive_scene::{Scene, Visual};
 use massive_shapes::TextWeight;
-use massive_shell::{shell, ApplicationContext};
+use massive_shell::{ApplicationContext, shell};
 use shared::{
     application::{Application, UpdateResponse},
     attributed_text::{self, TextAttribute},

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "massive-renderer"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+
+[profile.release]
+panic = "abort"
+
+[profile.dev]
+panic = "abort"
 
 [features]
 dump_edge = []

--- a/renderer/src/glyph/distance_field_gen.rs
+++ b/renderer/src/glyph/distance_field_gen.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::needless_range_loop)]
+#![allow(unsafe_op_in_unsafe_fn)]
 
 // Ported from Skia Milestone 115.
 
@@ -150,13 +151,7 @@ fn edge_distance(direction: Point, alpha: f32) -> f32 {
     }
     // this is easier if we treat the direction as being in the first octant
     // (other octants are symmetrical)
-    let (dx, dy) = {
-        if dx < dy {
-            (dy, dx)
-        } else {
-            (dx, dy)
-        }
-    };
+    let (dx, dy) = { if dx < dy { (dy, dx) } else { (dx, dy) } };
 
     // a1 = 0.5*dy/dx is the smaller fractional area chopped off by the edge
     // to avoid the divide, we just consider the numerator

--- a/renderer/src/glyph/glyph_atlas.rs
+++ b/renderer/src/glyph/glyph_atlas.rs
@@ -1,7 +1,7 @@
 //! A  wgpu glyph atlas for u8 textures. Inspired by glyphon's TextAtlas.
 use std::collections::HashMap;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use cosmic_text::{SwashContent, SwashImage};
 pub use etagere::Rectangle;
 use etagere::{Allocation, BucketedAtlasAllocator, Point};

--- a/renderer/src/glyph/glyph_cache.rs
+++ b/renderer/src/glyph/glyph_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map::Entry};
 
 use anyhow::Result;
 use cosmic_text as text;

--- a/renderer/src/glyph/glyph_rasterization.rs
+++ b/renderer/src/glyph/glyph_rasterization.rs
@@ -6,8 +6,8 @@ use swash::{
 use text::SwashContent;
 
 use super::{
-    distance_field_gen::{generate_distance_field_from_image, DISTANCE_FIELD_PAD},
     RasterizedGlyphKey, SwashRasterizationParam,
+    distance_field_gen::{DISTANCE_FIELD_PAD, generate_distance_field_from_image},
 };
 
 /// Rasterize a glyph into [`SwashImage`] as either monochrome, colored, or SDF, with appropriate

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -12,9 +12,11 @@ mod size_buffer;
 mod text_layer;
 mod texture;
 mod tools;
+mod transactions;
 
 pub use color_buffer::*;
 pub use renderer::Renderer;
+pub use transactions::*;
 // Cleanup: This is old, unused and should be removed.
 pub use shape_renderer::*;
 pub use size_buffer::*;

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -3,7 +3,7 @@ mod glyph;
 mod pipelines;
 mod pods;
 mod primitives;
-mod quads;
+// mod quads;
 mod renderer;
 mod scene;
 mod shape;

--- a/renderer/src/pipelines.rs
+++ b/renderer/src/pipelines.rs
@@ -3,7 +3,7 @@ use crate::{
     pods::{TextureColorVertex, TextureVertex},
     primitives::Pipeline,
     texture,
-    tools::{create_pipeline, BindGroupLayoutBuilder},
+    tools::{BindGroupLayoutBuilder, create_pipeline},
 };
 
 #[allow(unused)]

--- a/renderer/src/pods.rs
+++ b/renderer/src/pods.rs
@@ -109,6 +109,7 @@ impl TextureVertex {
     }
 }
 
+#[allow(unused)]
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
 pub struct ColorVertex {
@@ -116,6 +117,7 @@ pub struct ColorVertex {
     pub color: Color,
 }
 
+#[allow(unused)]
 impl ColorVertex {
     pub fn new(position: impl Into<Vertex>, color: impl Into<Color>) -> Self {
         Self {

--- a/renderer/src/renderer.rs
+++ b/renderer/src/renderer.rs
@@ -13,9 +13,7 @@ use wgpu::{PresentMode, StoreOp, SurfaceTexture};
 
 use crate::{
     TransactionManager, pipelines, pods,
-    quads::QuadsRenderer,
     scene::{LocationMatrices, Scene},
-    text,
     text_layer::TextLayerRenderer,
     texture,
 };

--- a/renderer/src/scene/dependency_resolver.rs
+++ b/renderer/src/scene/dependency_resolver.rs
@@ -1,4 +1,7 @@
-use super::versioning::{Computed, Version, Versioned};
+use crate::{
+    scene::versioning::{Computed, Versioned},
+    Version,
+};
 use massive_scene::Id;
 
 /// Resolve a computed value.

--- a/renderer/src/scene/dependency_resolver.rs
+++ b/renderer/src/scene/dependency_resolver.rs
@@ -1,6 +1,6 @@
 use crate::{
-    scene::versioning::{Computed, Versioned},
     Version,
+    scene::versioning::{Computed, Versioned},
 };
 use massive_scene::Id;
 

--- a/renderer/src/scene/dependency_resolver.rs
+++ b/renderer/src/scene/dependency_resolver.rs
@@ -23,8 +23,7 @@ pub fn resolve<Resolver: DependencyResolver>(
 {
     // Already validated at the latest version? Done.
     //
-    // `get_or_default` must be used here. This is the only situation in which the cache may
-    // need to be resized.
+    // This is the only situation in which the id might make the underlying storage to resize.
     if Resolver::computed_mut(computed_storage, id).validated_at == head_version {
         return;
     }

--- a/renderer/src/scene/id_table.rs
+++ b/renderer/src/scene/id_table.rs
@@ -18,7 +18,7 @@ impl<T> Default for IdTable<T> {
 }
 
 impl<T> IdTable<T> {
-    pub fn put(&mut self, id: Id, value: T)
+    pub fn insert(&mut self, id: Id, value: T)
     where
         T: Default,
     {

--- a/renderer/src/scene/location_matrices.rs
+++ b/renderer/src/scene/location_matrices.rs
@@ -1,0 +1,120 @@
+use euclid::num::Zero;
+use massive_geometry::Matrix4;
+use massive_scene::{Id, LocationRenderObj};
+
+use crate::{
+    scene::{
+        dependency_resolver::{resolve, DependencyResolver},
+        versioning::{Computed, Versioned},
+        IdTable, Scene,
+    },
+    Transaction, Version,
+};
+
+/// Computed matrices of all the visuals.
+#[derive(Debug, Default)]
+pub struct LocationMatrices {
+    // The result of a location matrix computation.
+    location_matrix: IdTable<Computed<Matrix4>>,
+}
+
+impl LocationMatrices {
+    pub fn compute_matrices(
+        &mut self,
+        scene: &Scene,
+        transaction: &Transaction,
+        locations: impl Iterator<Item = Id>,
+    ) {
+        locations.for_each(|id| {
+            self.compute_visual_matrix(scene, id, &transaction);
+        });
+    }
+
+    /// Returns a reference to a matrix of the location.
+    pub fn get(&self, location_id: Id) -> &Matrix4 {
+        &self.location_matrix[location_id]
+    }
+
+    /// Compute - if needed - the matrix of a location.
+    ///
+    /// When this function returns the matrix at `location_id` is up to date with the current
+    /// version and can be used for rendering.
+    fn compute_visual_matrix(
+        &mut self,
+        scene: &Scene,
+        location_id: Id,
+        current_version: &Transaction,
+    ) {
+        resolve::<VisualMatrix>(current_version.current_version(), scene, self, location_id);
+    }
+}
+
+/// The dependency resolver for final matrix of a [`Visual`].
+struct VisualMatrix;
+
+impl DependencyResolver for VisualMatrix {
+    type SharedStorage = Scene;
+    type ComputedStorage = LocationMatrices;
+    type Source = LocationRenderObj;
+    type Computed = Matrix4;
+
+    fn source(scene: &Scene, id: Id) -> &Versioned<Self::Source> {
+        scene.locations.get_unwrapped(id)
+    }
+
+    fn resolve_dependencies(
+        current_version: Version,
+        source: &Versioned<Self::Source>,
+        scene: &Scene,
+        caches: &mut LocationMatrices,
+    ) -> Version {
+        let (parent_id, matrix_id) = (source.parent, source.matrix);
+
+        // Find out the max version of all the immediate and (indirect / computed) dependencies.
+
+        // Get the _three_ versions of the elements this one is computed on.
+        // a) The self location's version.
+        // b) The local matrix's version.
+        // c) The computed matrix of the parent (representing all its dependencies).
+        let max_deps_version = source
+            .updated_at
+            .max(scene.matrices.get_unwrapped(matrix_id).updated_at);
+
+        // Combine with the optional parent location.
+        if let Some(parent_id) = parent_id {
+            // Make sure the parent is up to date.
+            resolve::<Self>(current_version, scene, caches, parent_id);
+            caches.location_matrix[parent_id]
+                .max_deps_version
+                .max(max_deps_version)
+        } else {
+            max_deps_version
+        }
+    }
+
+    fn computed_mut(caches: &mut LocationMatrices, id: Id) -> &mut Computed<Self::Computed> {
+        caches.location_matrix.mut_or_default(id)
+    }
+
+    fn compute(scene: &Scene, caches: &LocationMatrices, source: &Self::Source) -> Self::Computed {
+        let (parent_id, matrix_id) = (source.parent, source.matrix);
+        let local_matrix = &**scene.matrices.get_unwrapped(matrix_id);
+        parent_id.map_or_else(
+            || *local_matrix,
+            |parent_id| *caches.location_matrix[parent_id] * local_matrix,
+        )
+    }
+}
+
+/// This is here to avoid using `Option` in the computed IdTable.
+impl Default for Computed<Matrix4> {
+    fn default() -> Self {
+        Self {
+            validated_at: 0,
+            max_deps_version: 0,
+            // OO: is there a way to use `::ZERO` / the trait `ConstZero` from num_traits for
+            // example?
+            value: Matrix4::zero(),
+        }
+    }
+}

--- a/renderer/src/scene/location_matrices.rs
+++ b/renderer/src/scene/location_matrices.rs
@@ -3,12 +3,12 @@ use massive_geometry::Matrix4;
 use massive_scene::{Id, LocationRenderObj};
 
 use crate::{
-    scene::{
-        dependency_resolver::{resolve, DependencyResolver},
-        versioning::{Computed, Versioned},
-        IdTable, Scene,
-    },
     Transaction, Version,
+    scene::{
+        IdTable, Scene,
+        dependency_resolver::{DependencyResolver, resolve},
+        versioning::{Computed, Versioned},
+    },
 };
 
 /// Computed matrices of all the visuals.
@@ -26,7 +26,7 @@ impl LocationMatrices {
         locations: impl Iterator<Item = Id>,
     ) {
         locations.for_each(|id| {
-            self.compute_visual_matrix(scene, id, &transaction);
+            self.compute_visual_matrix(scene, id, transaction);
         });
     }
 

--- a/renderer/src/scene/mod.rs
+++ b/renderer/src/scene/mod.rs
@@ -6,8 +6,8 @@ use crate::{Transaction, Version};
 
 mod dependency_resolver;
 mod id_table;
-mod versioning;
 mod location_matrices;
+mod versioning;
 
 pub use id_table::IdTable;
 pub use location_matrices::LocationMatrices;

--- a/renderer/src/scene/mod.rs
+++ b/renderer/src/scene/mod.rs
@@ -1,18 +1,16 @@
-use std::{cell::RefCell, collections::HashMap};
-
-use euclid::num::Zero;
-
-use dependency_resolver::{resolve, DependencyResolver};
-use id_table::IdTable;
 use massive_geometry::Matrix4;
-use massive_scene::{Change, Id, LocationRenderObj, SceneChange, Shape, VisualRenderObj};
-use versioning::{Computed, Versioned};
+use massive_scene::{Change, Id, LocationRenderObj, SceneChange, VisualRenderObj};
+use versioning::Versioned;
 
 use crate::{Transaction, Version};
 
 mod dependency_resolver;
 mod id_table;
 mod versioning;
+mod location_matrices;
+
+pub use id_table::IdTable;
+pub use location_matrices::LocationMatrices;
 
 #[derive(Debug, Default)]
 pub struct Scene {
@@ -25,8 +23,6 @@ pub struct Scene {
     locations: IdTable<Option<Versioned<LocationRenderObj>>>,
     // This is also versioned to allow the renderer to cache derived stuff.
     visuals: IdTable<Option<VisualRenderObj>>,
-
-    caches: RefCell<SceneCaches>,
 }
 
 impl Scene {
@@ -34,9 +30,9 @@ impl Scene {
     ///
     /// The transaction is given a new version number, which is then treated as the most recent
     /// version and the current version of the whole scene.
-    pub fn apply(&mut self, change: SceneChange, transaction: &Transaction) {
+    pub fn apply(&mut self, change: &SceneChange, transaction: &Transaction) {
         let current_version = transaction.current_version();
-        match change {
+        match change.clone() {
             SceneChange::Matrix(change) => self.matrices.apply_versioned(change, current_version),
             SceneChange::Location(change) => {
                 self.locations.apply_versioned(change, current_version)
@@ -45,106 +41,46 @@ impl Scene {
         }
     }
 
-    /// Returns a set of grouped shape by matrix.
-    pub fn grouped_shapes(
-        &self,
-        transaction: &Transaction,
-    ) -> impl Iterator<Item = (Matrix4, impl Iterator<Item = &Shape> + Clone)> {
-        let mut map: HashMap<Id, Vec<&[Shape]>> = HashMap::new();
+    // Returns a set of grouped shape by matrix.
+    // pub fn grouped_shapes(
+    //     &self,
+    //     transaction: &Transaction,
+    // ) -> impl Iterator<Item = (Matrix4, impl Iterator<Item = &Shape> + Clone)> {
+    //     let mut map: HashMap<Id, Vec<&[Shape]>> = HashMap::new();
 
-        for visual in self.visuals.iter_some() {
-            let location_id = visual.location;
-            map.entry(location_id).or_default().push(&visual.shapes);
-        }
+    //     for visual in self.visuals.iter_some() {
+    //         let location_id = visual.location;
+    //         map.entry(location_id).or_default().push(&visual.shapes);
+    //     }
 
-        // Update all matrices that are in use.
-        {
-            let version = transaction.current_version();
-            let mut caches = self.caches.borrow_mut();
-            for visual_id in map.keys() {
-                self.resolve_visual_matrix(*visual_id, version, &mut caches);
-            }
-        }
+    //     // Update all matrices that are in use.
+    //     {
+    //         let version = transaction.current_version();
+    //         let mut caches = self.caches.borrow_mut();
+    //         for location_id in map.keys() {
+    //             self.resolve_visual_matrix(*location_id, version, &mut caches);
+    //         }
+    //     }
 
-        // Create the group iterator.
+    //     // Create the group iterator.
 
-        let caches = self.caches.borrow();
+    //     let caches = self.caches.borrow();
 
-        map.into_iter().map(move |(visual_id, shapes)| {
-            // We can't return a reference to matrix, because this would also borrow `caches`.
-            let matrix = *caches.location_matrix[visual_id];
-            (matrix, shapes.into_iter().flatten())
-        })
-    }
-
-    /// Compute - if needed - the matrix of a location.
-    ///
-    /// When this function returns the matrix at `location_id` is up to date with the current
-    /// version and can be used for rendering.
-    fn resolve_visual_matrix(
-        &self,
-        location_id: Id,
-        current_version: Version,
-        caches: &mut SceneCaches,
-    ) {
-        resolve::<VisualMatrix>(current_version, self, caches, location_id);
-    }
+    //     map.into_iter().map(move |(visual_id, shapes)| {
+    //         // We can't return a reference to matrix, because this would also borrow `caches`.
+    //         let matrix = *caches.location_matrix[visual_id];
+    //         (matrix, shapes.into_iter().flatten())
+    //     })
+    // }
 }
 
-/// The dependency resolver for final matrix of a [`Visual`].
-struct VisualMatrix;
-
-impl DependencyResolver for VisualMatrix {
-    type SharedStorage = Scene;
-    type ComputedStorage = SceneCaches;
-    type Source = LocationRenderObj;
-    type Computed = Matrix4;
-
-    fn source(scene: &Scene, id: Id) -> &Versioned<Self::Source> {
-        scene.locations.get_unwrapped(id)
-    }
-
-    fn resolve_dependencies(
-        current_version: Version,
-        source: &Versioned<Self::Source>,
-        scene: &Scene,
-        caches: &mut SceneCaches,
-    ) -> Version {
-        let (parent_id, matrix_id) = (source.parent, source.matrix);
-
-        // Find out the max version of all the immediate and (indirect / computed) dependencies.
-
-        // Get the _three_ versions of the elements this one is computed on.
-        // a) The self location's version.
-        // b) The local matrix's version.
-        // c) The computed matrix of the parent (representing all its dependencies).
-        let max_deps_version = source
-            .updated_at
-            .max(scene.matrices.get_unwrapped(matrix_id).updated_at);
-
-        // Combine with the optional parent.
-        if let Some(parent_id) = parent_id {
-            // Make sure the parent is up to date.
-            resolve::<Self>(current_version, scene, caches, parent_id);
-            caches.location_matrix[parent_id]
-                .max_deps_version
-                .max(max_deps_version)
-        } else {
-            max_deps_version
+impl<T> IdTable<Option<Versioned<T>>> {
+    pub fn apply_versioned(&mut self, change: Change<T>, version: Version) {
+        match change {
+            Change::Create(id, value) => self.insert(id, Some(Versioned::new(value, version))),
+            Change::Delete(id) => self[id] = None,
+            Change::Update(id, value) => self[id] = Some(Versioned::new(value, version)),
         }
-    }
-
-    fn computed_mut(caches: &mut SceneCaches, id: Id) -> &mut Computed<Self::Computed> {
-        caches.location_matrix.mut_or_default(id)
-    }
-
-    fn compute(scene: &Scene, caches: &SceneCaches, source: &Self::Source) -> Self::Computed {
-        let (parent_id, matrix_id) = (source.parent, source.matrix);
-        let local_matrix = &**scene.matrices.get_unwrapped(matrix_id);
-        parent_id.map_or_else(
-            || *local_matrix,
-            |parent_id| *caches.location_matrix[parent_id] * local_matrix,
-        )
     }
 }
 
@@ -156,7 +92,7 @@ impl<T> IdTable<Option<T>> {
 
     pub fn apply(&mut self, change: Change<T>) {
         match change {
-            Change::Create(id, value) => self.put(id, Some(value)),
+            Change::Create(id, value) => self.insert(id, Some(value)),
             Change::Delete(id) => self[id] = None,
             Change::Update(id, value) => {
                 // A value at this index must exist, so use `rows_mut()` here.
@@ -171,32 +107,4 @@ impl<T> IdTable<Option<T>> {
     pub fn get_unwrapped(&self, id: Id) -> &T {
         self[id].as_ref().unwrap()
     }
-}
-
-impl<T> IdTable<Option<Versioned<T>>> {
-    pub fn apply_versioned(&mut self, change: Change<T>, version: Version) {
-        match change {
-            Change::Create(id, value) => self.put(id, Some(Versioned::new(value, version))),
-            Change::Delete(id) => self[id] = None,
-            Change::Update(id, value) => self[id] = Some(Versioned::new(value, version)),
-        }
-    }
-}
-
-impl Default for Computed<Matrix4> {
-    fn default() -> Self {
-        Self {
-            validated_at: 0,
-            max_deps_version: 0,
-            // OO: is there a way to use `::ZERO` / the trait `ConstZero` from num_traits for
-            // example?
-            value: Matrix4::zero(),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct SceneCaches {
-    // The result of a location matrix computation.
-    location_matrix: IdTable<Computed<Matrix4>>,
 }

--- a/renderer/src/scene/versioning.rs
+++ b/renderer/src/scene/versioning.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-pub type Version = u64;
+use crate::Version;
 
 #[derive(Debug)]
 pub struct Versioned<T> {

--- a/renderer/src/shape/bind_group.rs
+++ b/renderer/src/shape/bind_group.rs
@@ -1,6 +1,6 @@
 use derive_more::Deref;
 
-use crate::{bind_group_entries, tools::BindGroupLayoutBuilder, SizeBuffer};
+use crate::{SizeBuffer, bind_group_entries, tools::BindGroupLayoutBuilder};
 
 /// The bind group layout of a texture.
 #[derive(Debug, Deref)]

--- a/renderer/src/shape_renderer.rs
+++ b/renderer/src/shape_renderer.rs
@@ -8,11 +8,11 @@ use tracing::instrument;
 use wgpu::Device;
 
 use crate::{
+    ColorBuffer,
     glyph::{GlyphCache, GlyphClass, GlyphRasterizationParam, RasterizedGlyphKey},
     primitives::Primitive,
     texture::{self, Texture},
     tools::texture_sampler,
-    ColorBuffer,
 };
 use massive_geometry::{Matrix4, Point};
 use massive_shapes::{GlyphRun, GlyphRunShape, RunGlyph, Shape};

--- a/renderer/src/text_layer/color_atlas/mod.rs
+++ b/renderer/src/text_layer/color_atlas/mod.rs
@@ -4,19 +4,10 @@ mod bind_group;
 mod renderer;
 
 pub use bind_group::*;
-use massive_geometry::{Matrix4, Point3};
+use massive_geometry::Point3;
 pub use renderer::*;
 
 use crate::glyph::glyph_atlas;
-
-pub struct QuadBatch {
-    // Matrix is not prepared as a buffer, because it is combined with the camera matrix before
-    // uploading to the shader.
-    model_matrix: Matrix4,
-    fs_bind_group: wgpu::BindGroup,
-    vertex_buffer: wgpu::Buffer,
-    quad_count: usize,
-}
 
 #[derive(Debug)]
 pub struct QuadInstance {

--- a/renderer/src/text_layer/color_atlas/renderer.rs
+++ b/renderer/src/text_layer/color_atlas/renderer.rs
@@ -1,26 +1,24 @@
+use massive_scene::Matrix;
 use wgpu::{
-    util::{BufferInitDescriptor, DeviceExt},
     TextureFormat,
+    util::{BufferInitDescriptor, DeviceExt},
 };
-
-use massive_geometry::Matrix4;
 
 use crate::{
     glyph::GlyphAtlas,
     pods::TextureVertex,
     renderer::{PreparationContext, RenderContext},
-    tools::{create_pipeline, texture_sampler, QuadIndexBuffer},
+    text_layer::{QuadBatch, color_atlas::QuadInstance},
+    tools::{QuadIndexBuffer, create_pipeline, texture_sampler},
 };
 
-use super::{BindGroupLayout, QuadBatch, QuadInstance};
+use super::BindGroupLayout;
 
 pub struct ColorAtlasRenderer {
     pub atlas: GlyphAtlas,
     texture_sampler: wgpu::Sampler,
     pipeline: wgpu::RenderPipeline,
     fs_bind_group_layout: BindGroupLayout,
-    // OO: Share this sucker.
-    index_buffer: QuadIndexBuffer,
 }
 
 impl ColorAtlasRenderer {
@@ -62,7 +60,6 @@ impl ColorAtlasRenderer {
             texture_sampler: texture_sampler::linear_clamping(device),
             fs_bind_group_layout,
             pipeline,
-            index_buffer: QuadIndexBuffer::new(device),
         }
     }
 
@@ -70,7 +67,6 @@ impl ColorAtlasRenderer {
     pub fn batch(
         &mut self,
         context: &PreparationContext,
-        model_matrix: &Matrix4,
         instances: &[QuadInstance],
     ) -> Option<QuadBatch> {
         if instances.is_empty() {
@@ -104,71 +100,42 @@ impl ColorAtlasRenderer {
         });
 
         let bind_group = self.fs_bind_group_layout.create_bind_group(
-            context.device,
+            device,
             self.atlas.texture_view(),
             &self.texture_sampler,
         );
 
-        // Grow index buffer as needed.
-
-        let quad_count = instances.len();
-        self.index_buffer
-            .ensure_can_index_num_quads(context.device, quad_count);
-
         Some(QuadBatch {
-            model_matrix: *model_matrix,
             fs_bind_group: bind_group,
             vertex_buffer,
-            quad_count,
+            quad_count: instances.len(),
         })
     }
 
-    pub fn render(&self, context: &mut RenderContext, batches: &[QuadBatch]) {
-        // `set_index_buffer` will fail with empty buffers, so exit early if there is nothing to do.
-        if batches.is_empty() {
-            return;
-        }
-
+    pub fn prepare(&self, context: &mut RenderContext) {
         let pass = &mut context.pass;
         pass.set_pipeline(&self.pipeline);
+
         // DI: May do this inside this renderer and pass a Matrix to prepare?.
         pass.set_bind_group(0, context.view_projection_bind_group, &[]);
-        // DI: May share index buffers between renderers?
-        //
-        // OO: Don't pass the full index buffer here, only what's actually needed (it is growing
-        // only)
+    }
 
-        let max_quads = batches
-            .iter()
-            .map(|b| b.quad_count)
-            .max()
-            .unwrap_or_default();
+    pub fn render(&self, context: &mut RenderContext, model_matrix: &Matrix, batch: &QuadBatch) {
+        let text_layer_matrix = context.view_projection_matrix * model_matrix;
 
-        self.index_buffer.set(pass, max_quads);
+        // OO: Set bind group only once and update the buffer?
+        context.queue_view_projection_matrix(&text_layer_matrix);
 
-        for QuadBatch {
-            model_matrix,
-            fs_bind_group,
-            vertex_buffer,
-            quad_count,
-        } in batches
-        {
-            let text_layer_matrix = context.view_projection_matrix * model_matrix;
+        let pass = &mut context.pass;
+        pass.set_bind_group(0, context.view_projection_bind_group, &[]);
 
-            // OO: Set bind group only once and update the buffer?
-            context.queue_view_projection_matrix(&text_layer_matrix);
+        pass.set_bind_group(1, &batch.fs_bind_group, &[]);
+        pass.set_vertex_buffer(0, batch.vertex_buffer.slice(..));
 
-            let pass = &mut context.pass;
-            pass.set_bind_group(0, context.view_projection_bind_group, &[]);
-
-            pass.set_bind_group(1, fs_bind_group, &[]);
-            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-
-            pass.draw_indexed(
-                0..(quad_count * QuadIndexBuffer::INDICES_PER_QUAD) as u32,
-                0,
-                0..1,
-            )
-        }
+        pass.draw_indexed(
+            0..(batch.quad_count * QuadIndexBuffer::INDICES_PER_QUAD) as u32,
+            0,
+            0..1,
+        )
     }
 }

--- a/renderer/src/text_layer/renderer.rs
+++ b/renderer/src/text_layer/renderer.rs
@@ -5,7 +5,6 @@ use std::{
 
 use anyhow::Result;
 use cosmic_text::{self as text, FontSystem};
-use log::error;
 use massive_geometry::{Point, Point3};
 use massive_scene::{Change, Id, SceneChange, Shape, VisualRenderObj};
 use massive_shapes::{GlyphRun, RunGlyph, TextWeight};

--- a/renderer/src/text_layer/renderer.rs
+++ b/renderer/src/text_layer/renderer.rs
@@ -1,11 +1,15 @@
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
 
 use anyhow::Result;
-use cosmic_text as text;
-use massive_geometry::{Matrix4, Point, Point3};
-use massive_scene::Shape;
+use cosmic_text::{self as text, FontSystem};
+use log::error;
+use massive_geometry::{Point, Point3};
+use massive_scene::{Change, Id, SceneChange, Shape, VisualRenderObj};
 use massive_shapes::{GlyphRun, RunGlyph, TextWeight};
-use swash::{scale::ScaleContext, Weight};
+use swash::{Weight, scale::ScaleContext};
 use text::SwashContent;
 use wgpu::Device;
 
@@ -15,13 +19,21 @@ use super::{
 };
 use crate::{
     glyph::{
-        glyph_atlas, glyph_rasterization::rasterize_glyph_with_padding, GlyphRasterizationParam,
-        RasterizedGlyphKey, SwashRasterizationParam,
+        GlyphRasterizationParam, RasterizedGlyphKey, SwashRasterizationParam, glyph_atlas,
+        glyph_rasterization::rasterize_glyph_with_padding,
     },
     renderer::{PreparationContext, RenderContext},
+    scene::{IdTable, LocationMatrices},
+    tools::QuadIndexBuffer,
 };
 
 pub struct TextLayerRenderer {
+    // Optimization: This is used for get_font() only, which needs &mut. In the long run, completely
+    // put the character renderer off-thread and run the rasterizers completely parallel (tokio is
+    // probably fine, too). This is needed as soon we need asynchronous optimization of rendered
+    // resolutions to match the pixel density.
+    // Architecture: We should wrap this in some kind of FontEnvironment, or RasterizerEnvironment?
+    font_system: Arc<Mutex<FontSystem>>,
     // Font cache and scratch buffers for the rasterizer.
     //
     // TODO: May make the Rasterizer a thing and put it in there alongside with its functions. This
@@ -29,11 +41,53 @@ pub struct TextLayerRenderer {
     scale_context: ScaleContext,
     empty_glyphs: HashSet<RasterizedGlyphKey>,
 
-    sdf_renderer: SdfAtlasRenderer,
-    sdf_batches: Vec<sdf_atlas::QuadBatch>,
+    index_buffer: QuadIndexBuffer,
 
+    sdf_renderer: SdfAtlasRenderer,
     color_renderer: ColorAtlasRenderer,
-    color_batches: Vec<color_atlas::QuadBatch>,
+
+    // Architecture:
+    //
+    // Visuals should be stored one layer above. After all, they contain all shapes,
+    // Quads for example?
+    /// Visual Id -> batch table.
+    visuals: IdTable<Option<Visual>>,
+
+    /// The maximum quads currently in use. This may be more than the index buffer can hold.
+    max_quads_in_use: usize,
+}
+
+struct Visual {
+    location_id: Id,
+    batches: VisualBatches,
+}
+
+/// Representing all batches in a visual.
+struct VisualBatches {
+    sdf: Option<QuadBatch>,
+    color: Option<QuadBatch>,
+}
+
+impl VisualBatches {
+    fn max_quads(&self) -> usize {
+        [
+            self.sdf.as_ref().map(|b| b.quad_count).unwrap_or_default(),
+            self.color
+                .as_ref()
+                .map(|b| b.quad_count)
+                .unwrap_or_default(),
+        ]
+        .into_iter()
+        .max()
+        .unwrap()
+    }
+}
+
+pub struct QuadBatch {
+    /// Contains texture reference(s) and the sampler configuration.
+    pub fs_bind_group: wgpu::BindGroup,
+    pub vertex_buffer: wgpu::Buffer,
+    pub quad_count: usize,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -45,82 +99,166 @@ enum AtlasKind {
 impl TextLayerRenderer {
     pub fn new(
         device: &Device,
+        font_system: Arc<Mutex<FontSystem>>,
         target_format: wgpu::TextureFormat,
         view_projection_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         Self {
             scale_context: ScaleContext::default(),
+            font_system,
             empty_glyphs: HashSet::new(),
-
+            index_buffer: QuadIndexBuffer::new(device),
             sdf_renderer: SdfAtlasRenderer::new(
                 device,
                 target_format,
                 view_projection_bind_group_layout,
             ),
-            sdf_batches: Vec::new(),
 
             color_renderer: ColorAtlasRenderer::new(
                 device,
                 target_format,
                 view_projection_bind_group_layout,
             ),
-            color_batches: Vec::new(),
+
+            visuals: IdTable::default(),
+            max_quads_in_use: 0,
         }
     }
 
-    pub fn prepare<'a>(
-        &mut self,
-        context: &mut PreparationContext,
-        shapes: &[(Matrix4, impl Iterator<Item = &'a Shape> + Clone)],
-    ) -> Result<()> {
-        self.sdf_batches.clear();
-        self.color_batches.clear();
-
-        for (matrix, shapes) in shapes {
-            // NB: could deref the pointer here using unsafe.
-            let (sdf_batch, color_batch) = self.prepare_runs(
-                context,
-                matrix,
-                // DI: Move this filter up (callers should just pass here what's needed).
-                // OO: clone() will clone the backing Vec.
-                shapes.clone().filter_map(|s| match s {
-                    Shape::GlyphRun(run) => Some(run),
-                    Shape::Quads(_) => None,
-                }),
-            )?;
-            self.sdf_batches.extend(sdf_batch.into_iter());
-            self.color_batches.extend(color_batch.into_iter());
+    // Architecture: Optimization:
+    //
+    // This immediately creates QuadBatches, meaning that if we apply a Create / Delete combination
+    // they would be destroyed before rendered. I think that we should create the QuadBatches later
+    // based on a actual usage (and even later visibility) analysis?
+    pub fn apply(&mut self, change: &SceneChange, context: &mut PreparationContext) -> Result<()> {
+        if let SceneChange::Visual(visual_change) = change {
+            match visual_change {
+                Change::Create(id, visual) | Change::Update(id, visual) => {
+                    self.insert(*id, visual, context)?;
+                }
+                Change::Delete(id) => {
+                    self.delete(*id);
+                }
+            }
         }
-
         Ok(())
     }
 
-    pub fn render(&self, context: &mut RenderContext) {
-        self.sdf_renderer.render(context, &self.sdf_batches);
-        self.color_renderer.render(context, &self.color_batches);
+    pub fn insert(
+        &mut self,
+        id: Id,
+        visual: &VisualRenderObj,
+        context: &mut PreparationContext,
+    ) -> Result<()> {
+        let runs = visual.shapes.iter().filter_map(|s| match s {
+            Shape::GlyphRun(run) => Some(run),
+            Shape::Quads(_) => None,
+        });
+
+        let batches = self.runs_to_batches(context, runs)?;
+        self.visuals.insert(
+            id,
+            Some(Visual {
+                location_id: visual.location,
+                batches,
+            }),
+        );
+        Ok(())
+    }
+
+    pub fn delete(&mut self, id: Id) {
+        self.visuals[id] = None;
+    }
+
+    pub fn all_locations(&self) -> impl Iterator<Item = Id> {
+        let mut locations = HashSet::new();
+        for visual in self.visuals.iter_some() {
+            locations.insert(visual.location_id);
+        }
+        locations.into_iter()
+    }
+
+    pub fn prepare(&mut self, context: &mut PreparationContext) {
+        // Optimization: Visuals are iterated 4 times per render (see all_locations(), which could
+        // also compute max_quads).
+
+        // Compute only one max_quads value (which is optimal when we use one index buffer only).
+        let max_quads = self
+            .visuals
+            .iter_some()
+            .map(|v| v.batches.max_quads())
+            .max()
+            .unwrap_or_default();
+
+        self.index_buffer
+            .ensure_can_index_num_quads(context.device, max_quads);
+
+        self.max_quads_in_use = max_quads;
+    }
+
+    pub fn render(&self, matrices: &LocationMatrices, context: &mut RenderContext) {
+        if self.max_quads_in_use == 0 {
+            return;
+        }
+
+        // Set the shared index buffer for all quad renderers.
+        self.index_buffer
+            .set(&mut context.pass, self.max_quads_in_use);
+
+        {
+            // Optimization: Don't call prepare if there is nothing to render.
+            self.sdf_renderer.prepare(context);
+
+            for visual in self.visuals.iter_some() {
+                let model_matrix = context.pixel_matrix * matrices.get(visual.location_id);
+                if let Some(ref sdf_batch) = visual.batches.sdf {
+                    self.sdf_renderer.render(context, &model_matrix, sdf_batch);
+                }
+            }
+        }
+
+        {
+            // Optimization: Don't call prepare if there is nothing to render.
+            self.color_renderer.prepare(context);
+
+            for visual in self.visuals.iter_some() {
+                let model_matrix = context.pixel_matrix * matrices.get(visual.location_id);
+                if let Some(ref color_batch) = visual.batches.color {
+                    self.color_renderer
+                        .render(context, &model_matrix, color_batch);
+                }
+            }
+        }
     }
 
     /// Prepare a number of glyph runs and produce a TextLayer.
     ///
     /// All of the runs use the same model matrix.
-    fn prepare_runs<'a>(
+    fn runs_to_batches<'a>(
         &mut self,
         context: &mut PreparationContext,
-        model_matrix: &Matrix4,
-        // TODO: this double reference is quite unusual here
         runs: impl Iterator<Item = &'a GlyphRun>,
-    ) -> Result<(Option<sdf_atlas::QuadBatch>, Option<color_atlas::QuadBatch>)> {
+    ) -> Result<VisualBatches> {
         // Step 1: Get all instance data.
         // OO: Compute a conservative capacity?
         let mut sdf_glyphs = Vec::new();
         let mut color_glyphs = Vec::new();
 
+        // Architecture: We should really not lock this for a longer period of time. After initial
+        // renderers, it's usually not used anymore, because it just invokes get_font() on
+        // non-existing glyphs.0
+        let font_system = self.font_system.clone();
+        let mut font_system = font_system.lock().unwrap();
+
         for run in runs {
             let translation = run.translation;
             for glyph in &run.glyphs {
-                if let Some((rect, placement, kind)) =
-                    self.rasterized_glyph_atlas_rect(context, run.text_weight, glyph)?
-                {
+                if let Some((rect, placement, kind)) = self.rasterized_glyph_atlas_rect(
+                    context,
+                    &mut font_system,
+                    run.text_weight,
+                    glyph,
+                )? {
                     // OO: translation might be applied to two points only (lt, rb)
                     let vertices =
                         Self::glyph_vertices(run, glyph, &placement).map(|p| p + translation);
@@ -143,19 +281,20 @@ impl TextLayerRenderer {
             }
         }
 
-        let sdf_batch = self.sdf_renderer.batch(context, model_matrix, &sdf_glyphs);
+        let sdf_batch = self.sdf_renderer.batch(context, &sdf_glyphs);
+        let color_batch = self.color_renderer.batch(context, &color_glyphs);
 
-        let color_batch = self
-            .color_renderer
-            .batch(context, model_matrix, &color_glyphs);
-
-        Ok((sdf_batch, color_batch))
+        Ok(VisualBatches {
+            sdf: sdf_batch,
+            color: color_batch,
+        })
     }
 
     // This makes sure that there is a rasterized glyph in the atlas and returns the rectangle.
     fn rasterized_glyph_atlas_rect(
         &mut self,
         context: &mut PreparationContext,
+        font_system: &mut FontSystem,
         weight: TextWeight,
         glyph: &RunGlyph,
     ) -> Result<Option<(glyph_atlas::Rectangle, text::Placement, AtlasKind)>> {
@@ -185,7 +324,7 @@ impl TextLayerRenderer {
 
         // Not yet in an atlas and not empty. Now rasterize.
         let Some(image) =
-            rasterize_glyph_with_padding(context.font_system, &mut self.scale_context, &glyph_key)
+            rasterize_glyph_with_padding(font_system, &mut self.scale_context, &glyph_key)
         else {
             self.empty_glyphs.insert(glyph_key);
             return Ok(None);

--- a/renderer/src/text_layer/sdf_atlas/mod.rs
+++ b/renderer/src/text_layer/sdf_atlas/mod.rs
@@ -4,20 +4,10 @@ mod bind_group;
 mod renderer;
 
 pub use bind_group::*;
-use massive_geometry::{Color, Matrix4, Point3};
+use massive_geometry::{Color, Point3};
 pub use renderer::*;
 
 use crate::glyph::glyph_atlas;
-
-pub struct QuadBatch {
-    // Matrix is not prepared as a buffer, because it is combined with the camera matrix before
-    // uploading to the shader.
-    model_matrix: Matrix4,
-    /// Contains texture reference(s) and the sampler configuration.
-    fs_bind_group: wgpu::BindGroup,
-    vertex_buffer: wgpu::Buffer,
-    quad_count: usize,
-}
 
 #[derive(Debug)]
 pub struct QuadInstance {

--- a/renderer/src/text_layer/sdf_atlas/mod.rs
+++ b/renderer/src/text_layer/sdf_atlas/mod.rs
@@ -13,6 +13,7 @@ pub struct QuadBatch {
     // Matrix is not prepared as a buffer, because it is combined with the camera matrix before
     // uploading to the shader.
     model_matrix: Matrix4,
+    /// Contains texture reference(s) and the sampler configuration.
     fs_bind_group: wgpu::BindGroup,
     vertex_buffer: wgpu::Buffer,
     quad_count: usize,

--- a/renderer/src/text_layer/sdf_atlas/renderer.rs
+++ b/renderer/src/text_layer/sdf_atlas/renderer.rs
@@ -132,8 +132,10 @@ impl SdfAtlasRenderer {
 
         let pass = &mut context.pass;
         pass.set_pipeline(&self.pipeline);
+
         // DI: May do this inside this renderer and pass a Matrix to prepare?.
         pass.set_bind_group(0, context.view_projection_bind_group, &[]);
+
         // Optimization: May share index buffers between renderers?
         let max_quads = batches
             .iter()
@@ -141,6 +143,8 @@ impl SdfAtlasRenderer {
             .max()
             .unwrap_or_default();
 
+        // Optimization: We could increase its capacity at this point when needed.
+        // Architecture: Share it and call it quad_index_buffer.
         self.index_buffer.set(pass, max_quads);
 
         for QuadBatch {
@@ -156,8 +160,10 @@ impl SdfAtlasRenderer {
             context.queue_view_projection_matrix(&text_layer_matrix);
 
             let pass = &mut context.pass;
+            // Set this only once? I thinkg this should be possible.
             pass.set_bind_group(0, context.view_projection_bind_group, &[]);
 
+            // Also, this is mostly the same, set this only once.
             pass.set_bind_group(1, fs_bind_group, &[]);
             pass.set_vertex_buffer(0, vertex_buffer.slice(..));
 

--- a/renderer/src/text_layer/sdf_atlas/renderer.rs
+++ b/renderer/src/text_layer/sdf_atlas/renderer.rs
@@ -1,26 +1,23 @@
+use massive_scene::Matrix;
 use wgpu::{
     util::{BufferInitDescriptor, DeviceExt},
     TextureFormat,
 };
 
-use massive_geometry::Matrix4;
-
+use super::BindGroupLayout;
 use crate::{
     glyph::GlyphAtlas,
     pods::TextureColorVertex,
     renderer::{PreparationContext, RenderContext},
+    text_layer::{sdf_atlas::QuadInstance, QuadBatch},
     tools::{create_pipeline, texture_sampler, QuadIndexBuffer},
 };
-
-use super::{BindGroupLayout, QuadBatch, QuadInstance};
 
 pub struct SdfAtlasRenderer {
     pub atlas: GlyphAtlas,
     texture_sampler: wgpu::Sampler,
     pipeline: wgpu::RenderPipeline,
     fs_bind_group_layout: BindGroupLayout,
-    // OO: Share this sucker.
-    index_buffer: QuadIndexBuffer,
 }
 
 impl SdfAtlasRenderer {
@@ -62,7 +59,6 @@ impl SdfAtlasRenderer {
             texture_sampler: texture_sampler::linear_clamping(device),
             fs_bind_group_layout,
             pipeline,
-            index_buffer: QuadIndexBuffer::new(device),
         }
     }
 
@@ -70,7 +66,6 @@ impl SdfAtlasRenderer {
     pub fn batch(
         &mut self,
         context: &PreparationContext,
-        model_matrix: &Matrix4,
         instances: &[QuadInstance],
     ) -> Option<QuadBatch> {
         if instances.is_empty() {
@@ -113,65 +108,45 @@ impl SdfAtlasRenderer {
         // Grow index buffer as needed.
 
         let quad_count = instances.len();
-        self.index_buffer
-            .ensure_can_index_num_quads(context.device, quad_count);
 
         Some(QuadBatch {
-            model_matrix: *model_matrix,
             fs_bind_group: bind_group,
             vertex_buffer,
             quad_count,
         })
     }
 
-    pub fn render(&self, context: &mut RenderContext, batches: &[QuadBatch]) {
-        // `set_index_buffer` will fail with empty buffers, so exit early if there is nothing to do.
-        if batches.is_empty() {
-            return;
-        }
-
+    // Architecture: Return some struct / context that enables repeated render(matrix, batch)
+    // invocations.
+    pub fn prepare(&self, context: &mut RenderContext) {
         let pass = &mut context.pass;
         pass.set_pipeline(&self.pipeline);
 
         // DI: May do this inside this renderer and pass a Matrix to prepare?.
         pass.set_bind_group(0, context.view_projection_bind_group, &[]);
+    }
 
-        // Optimization: May share index buffers between renderers?
-        let max_quads = batches
-            .iter()
-            .map(|b| b.quad_count)
-            .max()
-            .unwrap_or_default();
+    /// The prerequisites for calling render():
+    /// - A prepared quad index buffer
+    /// - prepare() invocation.
+    pub fn render(&self, context: &mut RenderContext, model_matrix: &Matrix, batch: &QuadBatch) {
+        let text_layer_matrix = context.view_projection_matrix * model_matrix;
 
-        // Optimization: We could increase its capacity at this point when needed.
-        // Architecture: Share it and call it quad_index_buffer.
-        self.index_buffer.set(pass, max_quads);
+        // Optimization: Set bind group only once and update the buffer?
+        context.queue_view_projection_matrix(&text_layer_matrix);
 
-        for QuadBatch {
-            model_matrix,
-            fs_bind_group,
-            vertex_buffer,
-            quad_count,
-        } in batches
-        {
-            let text_layer_matrix = context.view_projection_matrix * model_matrix;
+        let pass = &mut context.pass;
+        // Set this only once? I think this should be possible.
+        pass.set_bind_group(0, context.view_projection_bind_group, &[]);
 
-            // Optimization: Set bind group only once and update the buffer?
-            context.queue_view_projection_matrix(&text_layer_matrix);
+        // Also, this is mostly the same, set this only once.
+        pass.set_bind_group(1, &batch.fs_bind_group, &[]);
+        pass.set_vertex_buffer(0, batch.vertex_buffer.slice(..));
 
-            let pass = &mut context.pass;
-            // Set this only once? I thinkg this should be possible.
-            pass.set_bind_group(0, context.view_projection_bind_group, &[]);
-
-            // Also, this is mostly the same, set this only once.
-            pass.set_bind_group(1, fs_bind_group, &[]);
-            pass.set_vertex_buffer(0, vertex_buffer.slice(..));
-
-            pass.draw_indexed(
-                0..(quad_count * QuadIndexBuffer::INDICES_PER_QUAD) as u32,
-                0,
-                0..1,
-            )
-        }
+        pass.draw_indexed(
+            0..(batch.quad_count * QuadIndexBuffer::INDICES_PER_QUAD) as u32,
+            0,
+            0..1,
+        )
     }
 }

--- a/renderer/src/text_layer/sdf_atlas/renderer.rs
+++ b/renderer/src/text_layer/sdf_atlas/renderer.rs
@@ -1,7 +1,7 @@
 use massive_scene::Matrix;
 use wgpu::{
-    util::{BufferInitDescriptor, DeviceExt},
     TextureFormat,
+    util::{BufferInitDescriptor, DeviceExt},
 };
 
 use super::BindGroupLayout;
@@ -9,8 +9,8 @@ use crate::{
     glyph::GlyphAtlas,
     pods::TextureColorVertex,
     renderer::{PreparationContext, RenderContext},
-    text_layer::{sdf_atlas::QuadInstance, QuadBatch},
-    tools::{create_pipeline, texture_sampler, QuadIndexBuffer},
+    text_layer::{QuadBatch, sdf_atlas::QuadInstance},
+    tools::{QuadIndexBuffer, create_pipeline, texture_sampler},
 };
 
 pub struct SdfAtlasRenderer {

--- a/renderer/src/texture.rs
+++ b/renderer/src/texture.rs
@@ -1,7 +1,7 @@
-use tracing::{span, Level};
+use tracing::{Level, span};
 use wgpu::util::DeviceExt;
 
-use crate::{pods::TextureVertex, primitives::Pipeline, texture, ColorBuffer};
+use crate::{ColorBuffer, pods::TextureVertex, primitives::Pipeline, texture};
 use massive_geometry::Point3;
 
 mod bind_group;

--- a/renderer/src/texture/bind_group.rs
+++ b/renderer/src/texture/bind_group.rs
@@ -1,7 +1,7 @@
 use derive_more::Deref;
 
 use super::View;
-use crate::{bind_group_entries, tools::BindGroupLayoutBuilder, ColorBuffer};
+use crate::{ColorBuffer, bind_group_entries, tools::BindGroupLayoutBuilder};
 
 /// The bind group layout of a texture.
 #[derive(Debug, Deref)]

--- a/renderer/src/texture/view.rs
+++ b/renderer/src/texture/view.rs
@@ -1,4 +1,4 @@
-use crate::{tools::AsBindingResource, SizeBuffer};
+use crate::{SizeBuffer, tools::AsBindingResource};
 
 #[derive(Debug)]
 pub struct View {

--- a/renderer/src/tools/quad_index_buffer.rs
+++ b/renderer/src/tools/quad_index_buffer.rs
@@ -31,6 +31,7 @@ impl QuadIndexBuffer {
             .slice(..(max_quads * Self::INDICES_PER_QUAD * Self::INDEX_SIZE) as u64)
     }
 
+    // Optimization: Copy old data to the new buffer directly on the GPU
     pub fn ensure_can_index_num_quads(
         &mut self,
         device: &wgpu::Device,

--- a/renderer/src/tools/quad_index_buffer.rs
+++ b/renderer/src/tools/quad_index_buffer.rs
@@ -1,7 +1,7 @@
 use std::mem::{self, size_of_val};
 
 use log::debug;
-use wgpu::{util::DeviceExt, BufferSlice, IndexFormat, RenderPass};
+use wgpu::{BufferSlice, IndexFormat, RenderPass, util::DeviceExt};
 
 #[derive(Debug)]
 pub struct QuadIndexBuffer(wgpu::Buffer);
@@ -51,7 +51,9 @@ impl QuadIndexBuffer {
             assert!(proposed_quad_capacity != 0);
         }
 
-        debug!("Growing index buffer from {current} to {proposed_quad_capacity} quads, required: {required_quad_count}");
+        debug!(
+            "Growing index buffer from {current} to {proposed_quad_capacity} quads, required: {required_quad_count}"
+        );
 
         let indices = Self::generate_array(self, proposed_quad_capacity);
         self.0 = Self::create_buffer(device, &indices);

--- a/renderer/src/transactions.rs
+++ b/renderer/src/transactions.rs
@@ -1,0 +1,33 @@
+pub type Version = u64;
+
+/// The "TransactionManager" manages the current version of scene updates.
+///
+/// Introduced to be able to pass the current version to the various renderer.
+#[derive(Debug, Default)]
+pub struct TransactionManager {
+    current_version: Version,
+}
+
+impl TransactionManager {
+    pub fn new_transaction(&mut self) -> Transaction {
+        self.current_version += 1;
+        Transaction {
+            current_version: self.current_version,
+        }
+    }
+
+    pub fn current(&self) -> Version {
+        self.current_version
+    }
+}
+
+#[derive(Debug)]
+pub struct Transaction {
+    current_version: Version,
+}
+
+impl Transaction {
+    pub fn current_version(&self) -> Version {
+        self.current_version
+    }
+}

--- a/renderer/src/transactions.rs
+++ b/renderer/src/transactions.rs
@@ -11,6 +11,10 @@ pub struct TransactionManager {
 impl TransactionManager {
     pub fn new_transaction(&mut self) -> Transaction {
         self.current_version += 1;
+        self.current_transaction()
+    }
+
+    pub fn current_transaction(&mut self) -> Transaction {
         Transaction {
             current_version: self.current_version,
         }

--- a/scene/Cargo.toml
+++ b/scene/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "massive-scene"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 massive-shapes = { workspace = true }

--- a/scene/src/change.rs
+++ b/scene/src/change.rs
@@ -5,7 +5,7 @@ use massive_geometry::Matrix4;
 
 use crate::{Id, Location, LocationRenderObj, Visual, VisualRenderObj};
 
-#[derive(Debug, From)]
+#[derive(Debug, From, Clone)]
 pub enum SceneChange {
     Matrix(Change<Matrix4>),
     Location(Change<LocationRenderObj>),
@@ -24,9 +24,9 @@ impl SceneChange {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Change<T> {
     Create(Id, T),
-    Delete(Id),
     Update(Id, T),
+    Delete(Id),
 }

--- a/scene/src/objects.rs
+++ b/scene/src/objects.rs
@@ -28,7 +28,7 @@ pub struct Visual {
     pub shapes: Arc<[Shape]>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VisualRenderObj {
     pub location: Id,
     pub shapes: Arc<[Shape]>,
@@ -86,7 +86,7 @@ impl Object for Location {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LocationRenderObj {
     pub parent: Option<Id>,
     pub matrix: Id,

--- a/scene/src/scene.rs
+++ b/scene/src/scene.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::Result;
 
 use crate::{
-    type_id_generator::TypeIdGenerator, Change, ChangeCollector, Handle, Object, SceneChange,
+    Change, ChangeCollector, Handle, Object, SceneChange, type_id_generator::TypeIdGenerator,
 };
 
 /// A scene is the only direct connection of actual contents to the renderer. It tracks all the

--- a/scene/src/type_id_generator.rs
+++ b/scene/src/type_id_generator.rs
@@ -1,6 +1,6 @@
 use std::{any::TypeId, collections::HashMap};
 
-use crate::{id::Generator, Id};
+use crate::{Id, id::Generator};
 
 /// A (sharable) generator for ids per type.
 #[derive(Debug, Default)]

--- a/shapes/Cargo.toml
+++ b/shapes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "massive-shapes"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 massive-geometry = { workspace = true }

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "massive-shell"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+
+[profile.release]
+panic = "abort"
+
+[profile.dev]
+panic = "abort"
 
 [dependencies]
 massive-geometry = { workspace = true }

--- a/shell/src/application_context.rs
+++ b/shell/src/application_context.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use log::{error, info};
 use massive_geometry::Camera;
 use massive_scene::Scene;
@@ -16,8 +16,8 @@ use winit::{dpi, event::WindowEvent, event_loop::EventLoopProxy, window::WindowA
 use massive_animation::{Interpolatable, Interpolation, Tickery, Timeline};
 
 use crate::{
-    async_window_renderer::RendererMessage, AsyncWindowRenderer, ShellEvent, ShellRequest,
-    ShellWindow,
+    AsyncWindowRenderer, ShellEvent, ShellRequest, ShellWindow,
+    async_window_renderer::RendererMessage,
 };
 
 /// The [`ApplicationContext`] is the connection to the runtinme. It allows the application to poll

--- a/shell/src/async_window_renderer.rs
+++ b/shell/src/async_window_renderer.rs
@@ -2,17 +2,17 @@ use std::{
     collections::HashMap,
     mem,
     sync::{
-        mpsc::{self, Sender},
         Arc,
+        mpsc::{self, Sender},
     },
     thread::{self, JoinHandle},
     time::Instant,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use log::error;
 use tokio::sync::mpsc::{
-    error::TryRecvError, unbounded_channel, UnboundedReceiver, UnboundedSender,
+    UnboundedReceiver, UnboundedSender, error::TryRecvError, unbounded_channel,
 };
 use wgpu::PresentMode;
 use winit::window::WindowId;

--- a/shell/src/shell.rs
+++ b/shell/src/shell.rs
@@ -16,7 +16,7 @@ use winit::{
     window::{Window, WindowAttributes, WindowId},
 };
 
-use crate::{application_context::RenderPacing, ApplicationContext, ShellWindow};
+use crate::{ApplicationContext, ShellWindow, application_context::RenderPacing};
 use massive_animation::Tickery;
 
 pub async fn run<R: Future<Output = Result<()>> + 'static + Send>(

--- a/shell/src/shell_window.rs
+++ b/shell/src/shell_window.rs
@@ -5,18 +5,18 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use cosmic_text::FontSystem;
 use log::{error, info};
 use tokio::sync::oneshot;
-use wgpu::{rwh, Instance, InstanceDescriptor, Surface, SurfaceTarget};
+use wgpu::{Instance, InstanceDescriptor, Surface, SurfaceTarget, rwh};
 use winit::{
     dpi::PhysicalSize,
     event_loop::EventLoopProxy,
     window::{Window, WindowId},
 };
 
-use crate::{shell::ShellRequest, window_renderer::WindowRenderer, AsyncWindowRenderer};
+use crate::{AsyncWindowRenderer, shell::ShellRequest, window_renderer::WindowRenderer};
 use massive_geometry::Camera;
 
 #[derive(Clone)]


### PR DESCRIPTION
After thinking about how should a renderer preserve the incrementally provided by the application, I think it's best to directly push the changes to the individual (pipeline) renders for preparation. The renderers can then extract the changes that are interesting for them and directly and _incrementally_ create or update (even patch) their internal buffers and reference other renderers. 

I've also slighty adapted what a Renderer actually is defined as (upper "R"). A Renderer is just a components that prepares derived data (these can be GPU buffers, or something else, like the LocationStack, which computes the final matrices of the Visuals).

The first step here is to process all changes in lock-step, the second is to separate Create & Updates from Deletes (or even separate them in three separate cycles, primarily to make parallelization possible). Deletes must be all scheduled at the end to solve the [Delete after Create Problem](TBD) and to keep the referential integrity between Renderers while creating and updating buffers.

This (future) separation must also take Id recycling into account. Ids can't anymore be recycled when a Delete happens at the client, but earliest when the set of scene updates are fully packages and sent to the renderer and processed there as a single Transaction.
