### PR TITLE
Push the matrices as constants to the draw commands

### DIFF
--- a/examples/markdown/examples/markdown.rs
+++ b/examples/markdown/examples/markdown.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{HashMap, VecDeque},
-    f64::consts::PI,
     mem,
     sync::{Arc, Mutex},
 };
@@ -21,7 +20,7 @@ use log::info;
 use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
 use winit::dpi::PhysicalSize;
 
-use massive_geometry::{Camera, Matrix4, SizeI, Vector3};
+use massive_geometry::{Camera, SizeI, Vector3};
 use massive_scene::{Scene, Visual};
 use massive_shapes::GlyphRun;
 use massive_shell::{ApplicationContext, shell};
@@ -107,25 +106,9 @@ async fn application(mut ctx: ApplicationContext) -> Result<()> {
     let matrix = scene.stage(page_matrix);
     let location = scene.stage(matrix.clone().into());
 
-    let rotation_matrix = Matrix4::from_angle_y(cgmath::Deg(45.0));
-    let matrix2 = rotation_matrix * page_matrix;
-
-    let matrix2 = scene.stage(matrix2);
-
-    let location2 = scene.stage(matrix2.clone().into());
-
     // Hold the staged visual, otherwise it will disappear.
     let _visual = scene.stage(Visual::new(
         location,
-        glyph_runs
-            .clone()
-            .into_iter()
-            .map(|run| run.into())
-            .collect::<Vec<_>>(),
-    ));
-
-    let _visual2 = scene.stage(Visual::new(
-        location2.clone(),
         glyph_runs
             .clone()
             .into_iter()

--- a/renderer/src/pipelines.rs
+++ b/renderer/src/pipelines.rs
@@ -1,9 +1,8 @@
 use crate::{
-    bind_group_entries,
     pods::{TextureColorVertex, TextureVertex},
     primitives::Pipeline,
     texture,
-    tools::{BindGroupLayoutBuilder, create_pipeline},
+    tools::create_pipeline,
 };
 
 #[allow(unused)]
@@ -84,21 +83,4 @@ pub fn create(
         ),
     ]
     .into()
-}
-
-pub fn create_view_projection_bind_group(
-    device: &wgpu::Device,
-    view_projection_buffer: &wgpu::Buffer,
-) -> (wgpu::BindGroupLayout, wgpu::BindGroup) {
-    let layout = BindGroupLayoutBuilder::vertex_stage()
-        .uniform()
-        .build("View Projection Bind Group Layout", device);
-
-    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        layout: &layout,
-        entries: bind_group_entries!(0 => view_projection_buffer),
-        label: Some("Camera Bind Group"),
-    });
-
-    (layout, bind_group)
 }

--- a/renderer/src/pods.rs
+++ b/renderer/src/pods.rs
@@ -218,7 +218,7 @@ pub trait ToPod {
 
 pub trait AsBytes {
     fn as_bytes(&self) -> &[u8];
-    fn size<R: TryFrom<usize> + fmt::Debug>() -> R
+    fn size<R: TryFrom<usize>>() -> R
     where
         R::Error: fmt::Debug;
 }

--- a/renderer/src/pods.rs
+++ b/renderer/src/pods.rs
@@ -1,4 +1,7 @@
-use std::mem::size_of;
+use std::{
+    fmt,
+    mem::{self, size_of},
+};
 
 use bytemuck::{Pod, Zeroable};
 use static_assertions::const_assert_eq;
@@ -204,6 +207,49 @@ impl From<massive_geometry::Color> for InstanceColor {
     fn from(value: massive_geometry::Color) -> Self {
         Self {
             color: [value.red, value.green, value.blue],
+        }
+    }
+}
+
+pub trait ToPod {
+    type Pod;
+    fn to_pod(&self) -> Self::Pod;
+}
+
+pub trait AsBytes {
+    fn as_bytes(&self) -> &[u8];
+    fn size<R: TryFrom<usize> + fmt::Debug>() -> R
+    where
+        R::Error: fmt::Debug;
+}
+
+impl<T: Pod> AsBytes for T {
+    fn as_bytes(&self) -> &[u8] {
+        bytemuck::bytes_of(self)
+    }
+
+    fn size<R: TryFrom<usize>>() -> R
+    where
+        R::Error: fmt::Debug,
+    {
+        mem::size_of::<Self>()
+            .try_into()
+            .expect("Failed to convert usize to the required size type")
+    }
+}
+
+pub mod cgmath {
+    use crate::pods;
+
+    use super::ToPod;
+    use cgmath::Matrix4;
+
+    impl ToPod for Matrix4<f64> {
+        type Pod = super::Matrix4;
+
+        fn to_pod(&self) -> Self::Pod {
+            let m: Matrix4<f32> = self.cast().expect("Cast to Matrix4<f32>");
+            pods::Matrix4(m.into())
         }
     }
 }

--- a/renderer/src/text_layer/color_atlas/color_atlas.wgsl
+++ b/renderer/src/text_layer/color_atlas/color_atlas.wgsl
@@ -1,7 +1,6 @@
 // Vertex shader
 
-@group(0) @binding(0)
-var<uniform> view_model: mat4x4<f32>;
+var<push_constant> view_model: mat4x4<f32>;
 
 struct VertexInput {
     @location(0) position: vec3<f32>,
@@ -26,9 +25,9 @@ fn vs_main(
 
 // Fragment shader
 
-@group(1) @binding(0)
+@group(0) @binding(0)
 var t_texture: texture_2d<f32>;
-@group(1) @binding(1)
+@group(0) @binding(1)
 var s_sampler: sampler;
 
 @fragment

--- a/renderer/src/text_layer/renderer.rs
+++ b/renderer/src/text_layer/renderer.rs
@@ -100,25 +100,14 @@ impl TextLayerRenderer {
         device: &Device,
         font_system: Arc<Mutex<FontSystem>>,
         target_format: wgpu::TextureFormat,
-        view_projection_bind_group_layout: &wgpu::BindGroupLayout,
     ) -> Self {
         Self {
             scale_context: ScaleContext::default(),
             font_system,
             empty_glyphs: HashSet::new(),
             index_buffer: QuadIndexBuffer::new(device),
-            sdf_renderer: SdfAtlasRenderer::new(
-                device,
-                target_format,
-                view_projection_bind_group_layout,
-            ),
-
-            color_renderer: ColorAtlasRenderer::new(
-                device,
-                target_format,
-                view_projection_bind_group_layout,
-            ),
-
+            sdf_renderer: SdfAtlasRenderer::new(device, target_format),
+            color_renderer: ColorAtlasRenderer::new(device, target_format),
             visuals: IdTable::default(),
             max_quads_in_use: 0,
         }
@@ -209,8 +198,8 @@ impl TextLayerRenderer {
             self.sdf_renderer.prepare(context);
 
             for visual in self.visuals.iter_some() {
-                let model_matrix = context.pixel_matrix * matrices.get(visual.location_id);
                 if let Some(ref sdf_batch) = visual.batches.sdf {
+                    let model_matrix = context.pixel_matrix * matrices.get(visual.location_id);
                     self.sdf_renderer.render(context, &model_matrix, sdf_batch);
                 }
             }
@@ -221,8 +210,8 @@ impl TextLayerRenderer {
             self.color_renderer.prepare(context);
 
             for visual in self.visuals.iter_some() {
-                let model_matrix = context.pixel_matrix * matrices.get(visual.location_id);
                 if let Some(ref color_batch) = visual.batches.color {
+                    let model_matrix = context.pixel_matrix * matrices.get(visual.location_id);
                     self.color_renderer
                         .render(context, &model_matrix, color_batch);
                 }

--- a/renderer/src/text_layer/sdf_atlas/sdf_atlas.wgsl
+++ b/renderer/src/text_layer/sdf_atlas/sdf_atlas.wgsl
@@ -1,7 +1,6 @@
 // Vertex shader
 
-@group(0) @binding(0)
-var<uniform> view_model: mat4x4<f32>;
+var<push_constant> view_model: mat4x4<f32>;
 
 struct VertexInput {
     @location(0) position: vec3<f32>,
@@ -29,9 +28,9 @@ fn vs_main(
 
 // Fragment shader
 
-@group(1) @binding(0)
+@group(0) @binding(0)
 var t_texture: texture_2d<f32>;
-@group(1) @binding(1)
+@group(0) @binding(1)
 var s_sampler: sampler;
 
 // For the fragment shader:

--- a/renderer/src/tools/bind_group_layout_builder.rs
+++ b/renderer/src/tools/bind_group_layout_builder.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 pub struct BindGroupLayoutBuilder {
     shader_stages: wgpu::ShaderStages,
     entries: Vec<wgpu::BindGroupLayoutEntry>,


### PR DESCRIPTION
... which simplifies a lot and is support by all common backends AFAIK. This also fixes a problem with the current attempt that used only the matrix last updated in the pass.