### PR TITLE
Add basic support for custom shapes

### DIFF
--- a/examples/shapes/examples/shapes.rs
+++ b/examples/shapes/examples/shapes.rs
@@ -121,7 +121,7 @@ async fn run(mut ctx: ApplicationContext) -> Result<()> {
             Shape::StrokeRect(r) => r.rect,
             Shape::Ellipse(e) => e.rect,
             Shape::ChamferRect(r) => r.rect,
-            Shape::GlyphRun(_) => continue,
+            Shape::GlyphRun(_) | Shape::Custom(_) => continue,
         };
         bounds = Some(if let Some(b) = bounds { b.joined(r) } else { r });
     }
@@ -172,7 +172,7 @@ async fn run(mut ctx: ApplicationContext) -> Result<()> {
                 r.rect.top += offset_y;
                 r.rect.bottom += offset_y;
             }
-            Shape::GlyphRun(_) => {}
+            Shape::GlyphRun(_) | Shape::Custom(_) => {}
         }
     }
 

--- a/renderer/src/shape_renderer.rs
+++ b/renderer/src/shape_renderer.rs
@@ -140,7 +140,7 @@ impl ShapeRenderer {
 
         for shape in shapes.iter() {
             match shape {
-                Shape::GlyphRun(_) => {}
+                Shape::GlyphRun(..) => {}
                 Shape::Rect(r) => emit(&r.rect, ShapeSelector::Rect, (0.0, 0.0), r.color),
                 Shape::RoundRect(r) => emit(
                     &r.rect,
@@ -162,6 +162,7 @@ impl ShapeRenderer {
                     (s.stroke.width as f32, s.stroke.height as f32),
                     s.color,
                 ),
+                Shape::Custom(..) => {}
             }
         }
 


### PR DESCRIPTION
Together with configurable batch builders, this PR should make it possible to add custom pipeline renderer and shapes.