### PR TITLE
Remove the concept of logical coordinates from the input processing

### DIFF
--- a/input/src/detect.rs
+++ b/input/src/detect.rs
@@ -55,7 +55,7 @@ pub fn pressing(
 pub fn movement(
     history: &EventHistory,
     button: MouseButton,
-    min_distance: f64,
+    minimum_distance: f64,
 ) -> Option<Movement> {
     let current_event = history.current()?;
     let device_id = current_event.is_cursor_moved_event()?;
@@ -70,18 +70,19 @@ pub fn movement(
         .historic()
         .until(when_pressed)
         .max_distance_moved(device_id, from)
-        >= min_distance
+        >= minimum_distance
     {
         return None;
     }
     let pos_now = current_event.states.pos(device_id)?;
     let movement = pos_now - from;
-    (movement.length() >= min_distance).then(|| Movement {
+    (movement.length() >= minimum_distance).then(|| Movement {
         sensor,
         began: when_pressed,
         detected_after: current_event.time - when_pressed,
         from,
         delta: movement,
+        minimum_distance,
     })
 }
 
@@ -94,7 +95,7 @@ pub fn movement_inactivity(
     device: DeviceId,
     // How far should we go back to detect inactivity at max?
     check_range: Duration,
-    min_distance: f64,
+    minimum_distance: f64,
 ) -> Option<Duration> {
     // We take the current position as the basis for comparison (Should be symmetric).
     let current = history.current()?;
@@ -105,7 +106,7 @@ pub fn movement_inactivity(
         .until(current.time - check_range)
         .find(|r| {
             if let Some(pos) = r.states.pos(device) {
-                (current_pos - pos).length() >= min_distance
+                (current_pos - pos).length() >= minimum_distance
             } else {
                 false
             }

--- a/input/src/event.rs
+++ b/input/src/event.rs
@@ -131,7 +131,7 @@ impl Event {
 
     /// Detect several mouse gestures.
     ///
-    /// `min_distance` specifies the minimum movement for the detectino in physicial device
+    /// `min_distance` specifies the minimum movement for the detection in physical device
     /// coordinates.
     pub fn detect_mouse_gesture(
         &self,

--- a/input/src/event.rs
+++ b/input/src/event.rs
@@ -14,17 +14,6 @@ pub struct Event {
     /// Internal flag, that is set when a gesture detection needs regular tick events to function as
     /// expected.
     requires_ticks: Rc<Cell<bool>>,
-    // / Matrix conversion from logical window coordinates to coordinate system of the client. All
-    // / [`Point`]s returned here are translated through it.
-    // /
-    // / This conversion has the following purposes:
-    // / - to simplify the translation to another coordinate system.
-    // / - to enable gesture detection _while_ the client coordinate system changes.
-    // / - to make the gesture detection independent from the client coordinate system and so always
-    // /   use the logical screen coordinates.
-    // /
-    // / By default this is the identity matrix.
-    // matrix: Matrix,
 }
 
 impl Event {
@@ -36,19 +25,6 @@ impl Event {
             // matrix: default(),
         }
     }
-
-    // Transform the points returned from this event into another coordinate system.
-    //
-    // Consecutive transformation applied as seen from the incoming event that initially has
-    // logical window coordinates.
-    // pub fn transform(self, m: &Matrix) -> Event {
-    //     let matrix = Matrix::concat(&self.matrix, m);
-    //     Self { matrix, ..self }
-    // }
-
-    // pub fn map_point(&self, p: impl Into<Point>) -> Point {
-    //     self.matrix.map_point(p.into()).into()
-    // }
 
     pub fn pressed(&self, sensor: Sensor) -> bool {
         matches!(self.window_event(), Some(WindowEvent::MouseInput {
@@ -62,10 +38,9 @@ impl Event {
             }) if *device_id == sensor.device && *state == ElementState::Released)
     }
 
-    /// Returns the logical coordinates if the event is a pointer event.
+    /// Returns the physical coordinates if the event is a pointer event.
     pub fn pos(&self) -> Option<Point> {
         self.pointing_device().and_then(|di| self.states().pos(di))
-        // .map(|p| self.map_point(p))
     }
 
     pub fn pointing_device(&self) -> Option<DeviceId> {
@@ -133,9 +108,9 @@ impl Event {
         // .map(|p| self.map_point(p))
     }
 
+    // Detect a movement of >= `min_distance`. `min_distance` is in physical device coordinates.
     pub fn detect_movement(&self, button: MouseButton, min_distance: f64) -> Option<Movement> {
         detect::movement(&self.history, button, min_distance)
-        // .map(|m| m.transform(&self.matrix))
     }
 
     /*
@@ -154,13 +129,15 @@ impl Event {
         }
     */
 
-    // TODO: Fix magic value: minimum distance considered a move. This value must also
-    // dependent on the current zoom factor.
-    // TODO: this, together with enabling movement detection could be a `Param`.
-    pub const MIN_DISTANCE_FOR_MOVEMENT: f64 = 5.0;
-
     /// Detect several mouse gestures.
-    pub fn detect_mouse_gesture(&self, button: MouseButton) -> Option<MouseGesture> {
+    ///
+    /// `min_distance` specifies the minimum movement for the detectino in physicial device
+    /// coordinates.
+    pub fn detect_mouse_gesture(
+        &self,
+        button: MouseButton,
+        min_distance: f64,
+    ) -> Option<MouseGesture> {
         if let Some(point) = self.detect_double_click(button) {
             // TODO: This is to support `detect_pressing`.
             self.requires_ticks();
@@ -173,7 +150,7 @@ impl Event {
             return Some(MouseGesture::Click(point));
         }
 
-        if let Some(movement) = self.detect_movement(button, Self::MIN_DISTANCE_FOR_MOVEMENT) {
+        if let Some(movement) = self.detect_movement(button, min_distance) {
             return Some(MouseGesture::Movement(movement));
         }
 

--- a/input/src/event_aggregator.rs
+++ b/input/src/event_aggregator.rs
@@ -147,7 +147,7 @@ impl DeviceStates {
         self.keyboard_modifiers.contains(ModifiersState::SUPER)
     }
 
-    /// Returns the physcial coordinates of the pointing device.
+    /// Returns the physical coordinates of the pointing device.
     pub fn pos(&self, id: DeviceId) -> Option<Point> {
         self.pointing_device(id).and_then(|p| p.pos)
     }

--- a/input/src/event_aggregator.rs
+++ b/input/src/event_aggregator.rs
@@ -21,7 +21,7 @@ pub struct EventAggregator {
 }
 
 impl EventAggregator {
-    pub fn update(&mut self, event: &ExternalEvent, to_logical: impl Fn(Point) -> Point) {
+    pub fn update(&mut self, event: &ExternalEvent) {
         if let ExternalEvent::Window {
             ref event, time, ..
         } = *event
@@ -31,7 +31,7 @@ impl EventAggregator {
                     device_id,
                     position,
                     ..
-                } => self.cursor_moved(device_id, to_logical((position.x, position.y).into())),
+                } => self.cursor_moved(device_id, (position.x, position.y).into()),
                 WindowEvent::CursorEntered { device_id } => self.cursor_entered(device_id),
                 WindowEvent::CursorLeft { device_id } => {
                     self.cursor_left(device_id);
@@ -147,7 +147,7 @@ impl DeviceStates {
         self.keyboard_modifiers.contains(ModifiersState::SUPER)
     }
 
-    /// Returns the logical window coordinates of the pointing device.
+    /// Returns the physcial coordinates of the pointing device.
     pub fn pos(&self, id: DeviceId) -> Option<Point> {
         self.pointing_device(id).and_then(|p| p.pos)
     }

--- a/input/src/tracker/movement.rs
+++ b/input/src/tracker/movement.rs
@@ -19,6 +19,8 @@ pub struct Movement {
     pub from: Point,
     /// The current movement vector relative to `from`.
     pub delta: Vector,
+    /// What was the minimum distance used to detect this movement?
+    pub minimum_distance: f64,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -83,13 +85,4 @@ impl Movement {
             })
         )
     }
-
-    // pub fn transform(self, m: &Matrix) -> Movement {
-    //     // TODO: We need our own matrix type with a f64 component precision.
-    //     Self {
-    //         from: m.map_point(self.from).into(),
-    //         delta: m.map_vector(self.delta).into(),
-    //         ..self
-    //     }
-    // }
 }

--- a/input/src/tracker/movement_inactivity.rs
+++ b/input/src/tracker/movement_inactivity.rs
@@ -76,7 +76,7 @@ impl MovementInactivity {
         if let Some(duration) = event.detect_movement_inactivity(
             self.device(),
             self.inactivity_duration,
-            Self::MIN_DISTANCE_FOR_MOVEMENT,
+            self.minimum_distance,
         ) {
             return duration == self.inactivity_duration;
         }
@@ -85,12 +85,11 @@ impl MovementInactivity {
     }
 
     /// Return the current state of inactivity.
-    ///
     pub fn inactivity_state(&self, event: &Event) -> InactivityState {
         if let Some(inactivity) = event.detect_movement_inactivity(
             self.device(),
             self.inactivity_duration,
-            Self::MIN_DISTANCE_FOR_MOVEMENT,
+            self.minimum_distance,
         ) {
             let hint_start = self.hint_duration_start();
             let inactive = inactivity == self.inactivity_duration;
@@ -105,8 +104,6 @@ impl MovementInactivity {
         }
         InactivityState::default()
     }
-
-    const MIN_DISTANCE_FOR_MOVEMENT: f64 = Event::MIN_DISTANCE_FOR_MOVEMENT;
 
     fn device(&self) -> DeviceId {
         self.movement.sensor.device


### PR DESCRIPTION
Usually we process input movements / gestures, etc, in pixel coordinates anyway and only the gesture detection (more specifically movement detection distances) work on logical coordinates. So it does not make sense to transform events coming in from pixel to logical and when gestures are detected back from logical to pixel ( .. and then to the final client coordinate system).

This PR removes both steps and documents that distance inputs should be in logical units.